### PR TITLE
Feat/custom parent selector modal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # It uses the same pattern rule for gitignore file
 # https://git-scm.com/docs/gitignore#_pattern_format
 
-* @lojaintegrada/pagali @lojaintegrada/qa
+* @lojaintegrada/frontend @lojaintegrada/qa

--- a/styleguide/src/Components/Modal/Modal.stories.tsx
+++ b/styleguide/src/Components/Modal/Modal.stories.tsx
@@ -1,6 +1,5 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Story, Meta } from '@storybook/react'
-
 import { Modal, ModalProps } from './Modal'
 import { Box } from '../../Layout/Box'
 import { Button } from '../Button'
@@ -76,19 +75,55 @@ WithScroll.args = {
   ),
   footerActions: (
     <div className="flex justify-end">
-      <Button variant="secondary" className="mr-5">Some button</Button>
+      <Button variant="secondary" className="mr-5">
+        Some button
+      </Button>
       <Button>Some button</Button>
     </div>
-  )
+  ),
 }
 
 export const WithFooter = Template.bind({})
 WithFooter.args = {
-  headerClose: "Close",
+  headerClose: 'Close',
   footerActions: (
     <div className="flex justify-end">
-      <Button variant="secondary" className="mr-5">Some button</Button>
+      <Button variant="secondary" className="mr-5">
+        Some button
+      </Button>
       <Button>Some button</Button>
     </div>
+  ),
+}
+
+const TemplateWithId: Story<ModalProps> = (args) => {
+  const [newCustomArgs, setNewCustomArgs] = useState<ModalProps>()
+
+  useEffect(() => {
+    const customParentSelector = document.getElementById('parentSelector')
+    args.parentSelector = customParentSelector
+
+    setNewCustomArgs(args)
+  }, [])
+
+  return (
+    <div>
+      <div id="parentSelector">Content with parentSelector id</div>
+      {newCustomArgs && <Modal {...newCustomArgs} />}
+    </div>
   )
+}
+
+export const WithCustomParentSelector = TemplateWithId.bind({})
+WithCustomParentSelector.args = {
+  headerClose: 'Close',
+  footerActions: (
+    <div className="flex justify-end">
+      <Button variant="secondary" className="mr-5">
+        Some button
+      </Button>
+      <Button>Some button</Button>
+    </div>
+  ),
+  parentSelector: document.getElementById('parentSelector'),
 }

--- a/styleguide/src/Components/Modal/Modal.stories.tsx
+++ b/styleguide/src/Components/Modal/Modal.stories.tsx
@@ -85,7 +85,7 @@ WithScroll.args = {
 
 export const WithFooter = Template.bind({})
 WithFooter.args = {
-  headerClose: 'Close',
+  headerClose: "Close",
   footerActions: (
     <div className="flex justify-end">
       <Button variant="secondary" className="mr-5">

--- a/styleguide/src/Components/Modal/Modal.tsx
+++ b/styleguide/src/Components/Modal/Modal.tsx
@@ -17,6 +17,7 @@ const ModalComponent = ({
   headerClose = 'Fechar',
   footerActions,
   onClose,
+  parentSelector,
   children,
 }: ModalProps) => {
   const [modalIsOpen, setModalIsOpen] = useState(false)
@@ -43,6 +44,7 @@ const ModalComponent = ({
       className={`relative max-h-screen p-10 pt-9 rounded-lg shadow-lg flex flex-col w-full bg-base-1 outline-none focus:outline-none border border-card-stroke break-words ${sizeClasses[size]} ${className}`}
       bodyOpenClassName={'ReactModal__Body--open overflow-hidden'}
       testId={'modal-component'}
+      parentSelector={() => (parentSelector ? parentSelector : document.body)}
       contentElement={(props, children) => (
         <div {...props}>
           <div className="ReactModal__header w-full flex justify-between items-start">
@@ -112,4 +114,8 @@ export interface ModalProps {
    * React children
    */
   footerActions?: React.ReactNode
+  /** Function that will be called to get the parent element that the modal will be attached to
+   * @default document.body
+   */
+  parentSelector?: HTMLElement | null
 }

--- a/styleguide/src/Components/Modal/Modal.tsx
+++ b/styleguide/src/Components/Modal/Modal.tsx
@@ -114,7 +114,7 @@ export interface ModalProps {
    * React children
    */
   footerActions?: React.ReactNode
-  /** Function that will be called to get the parent element that the modal will be attached to
+  /** The parent element that the modal will be attached to
    * @default document.body
    */
   parentSelector?: HTMLElement | null

--- a/styleguide/src/Components/Modal/Modal.tsx
+++ b/styleguide/src/Components/Modal/Modal.tsx
@@ -115,7 +115,7 @@ export interface ModalProps {
    */
   footerActions?: React.ReactNode
   /** The parent element that the modal will be attached to
-   * @default document.body
+   * @default 'document.body'
    */
   parentSelector?: HTMLElement | null
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adicionar props para escolher qual elemento do DOM o modal vai ser fixado.

Novo exemplo do modal:
* Modal => With Custom Parent Selector

#### What problem is this solving?

Resolve o problema do modal sempre ficar fixo ao document.body e nunca poder ser usado fora do contexto de um iframe por exemplo.

#### How should this be manually tested?
Verificar se HTML do modal está dentro do container selecionado
<img width="783" alt="Captura de Tela 2021-08-31 às 17 54 49" src="https://user-images.githubusercontent.com/36740164/131574498-4c7489ec-935f-44ec-96a1-77d49243ec83.png">

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
