### PR TITLE
feat: add start/end input adornments

### DIFF
--- a/styleguide/src/Forms/Input/Input.spec.tsx
+++ b/styleguide/src/Forms/Input/Input.spec.tsx
@@ -3,13 +3,7 @@ import { composeStories } from '@storybook/testing-react'
 import { mount } from '@cypress/react'
 import * as stories from './Input.stories'
 
-const {
-  Default,
-  Error,
-  StartAdornment,
-  IconStartAdornment,
-  WithBothAdornment,
-} = composeStories(stories)
+const { Default, Error, Prefix, IconPrefix, WithBoth } = composeStories(stories)
 
 describe('Input tests', () => {
   it('Default', () => {
@@ -45,13 +39,13 @@ describe('Input tests', () => {
   })
 
   it('Adornments', () => {
-    mount(<StartAdornment />)
+    mount(<Prefix />)
     cy.get('span').contains('R$')
 
-    mount(<IconStartAdornment />)
+    mount(<IconPrefix />)
     cy.get('svg').should('have.class', 'icon-cog').parent('span')
 
-    mount(<WithBothAdornment />)
+    mount(<WithBoth />)
     cy.get('span').should('have.length', 2)
   })
 })

--- a/styleguide/src/Forms/Input/Input.spec.tsx
+++ b/styleguide/src/Forms/Input/Input.spec.tsx
@@ -1,12 +1,17 @@
-import * as React from "react"
-import { composeStories } from "@storybook/testing-react"
-import { mount } from "@cypress/react"
-import * as stories from "./Input.stories"
+import * as React from 'react'
+import { composeStories } from '@storybook/testing-react'
+import { mount } from '@cypress/react'
+import * as stories from './Input.stories'
 
-const { Default, Error } = composeStories(stories)
+const {
+  Default,
+  Error,
+  StartAdornment,
+  IconStartAdornment,
+  WithBothAdornment,
+} = composeStories(stories)
 
 describe('Input tests', () => {
-
   it('Default', () => {
     mount(<Default />)
     const val = 'Preencher campo'
@@ -39,4 +44,14 @@ describe('Input tests', () => {
     cy.get('input').should('have.class', 'h-24')
   })
 
+  it('Adornments', () => {
+    mount(<StartAdornment />)
+    cy.get('span').contains('R$')
+
+    mount(<IconStartAdornment />)
+    cy.get('svg').should('have.class', 'icon-cog').parent('span')
+
+    mount(<WithBothAdornment />)
+    cy.get('span').should('have.length', 2)
+  })
 })

--- a/styleguide/src/Forms/Input/Input.stories.tsx
+++ b/styleguide/src/Forms/Input/Input.stories.tsx
@@ -53,3 +53,29 @@ IconEndAdornment.args = {
   endAdornment: <Icon icon="cog" />,
   hasError: true,
 }
+
+export const StartAdornmentDisabled = Template.bind({})
+StartAdornmentDisabled.args = {
+  label: 'Meu Campo',
+  helpText: 'Texto de ajuda para preencher o campo',
+  startAdornment: 'R$',
+  disabled: true,
+  value: '123',
+}
+
+export const StartAdornmentReadOnly = Template.bind({})
+StartAdornmentReadOnly.args = {
+  label: 'Meu Campo',
+  helpText: 'Texto de ajuda para preencher o campo',
+  startAdornment: 'R$',
+  readOnly: true,
+  value: '123',
+}
+
+export const WithBothAdornment = Template.bind({})
+WithBothAdornment.args = {
+  label: 'Meu Campo',
+  helpText: 'Texto de ajuda para preencher o campo',
+  startAdornment: 'R$',
+  endAdornment: <Icon icon="cog" />,
+}

--- a/styleguide/src/Forms/Input/Input.stories.tsx
+++ b/styleguide/src/Forms/Input/Input.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Story, Meta } from '@storybook/react'
 
+import { Icon } from '../../Icons'
 import { Input, InputProps } from '.'
 
 export default {
@@ -8,7 +9,7 @@ export default {
   component: Input,
 } as Meta
 
-const Template: Story<InputProps> = args => <Input {...args} />
+const Template: Story<InputProps> = (args) => <Input {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
@@ -21,4 +22,34 @@ Error.args = {
   label: 'Meu Campo',
   helpText: 'Texto de ajuda para preencher o campo',
   errorMessage: 'Campo obrigatório',
+}
+
+export const StartAdornment = Template.bind({})
+StartAdornment.args = {
+  label: 'Meu Campo',
+  helpText: 'Texto de ajuda para preencher o campo',
+  startAdornment: 'R$',
+}
+
+export const IconStartAdornment = Template.bind({})
+IconStartAdornment.args = {
+  label: 'Meu Campo',
+  helpText: 'Texto de ajuda para preencher o campo',
+  startAdornment: <Icon icon="cog" />,
+  hasError: true,
+}
+
+export const EndAdornment = Template.bind({})
+EndAdornment.args = {
+  label: 'Meu Campo',
+  helpText: 'Texto de ajuda para preencher o campo',
+  endAdornment: 'R$',
+}
+
+export const IconEndAdornment = Template.bind({})
+IconEndAdornment.args = {
+  label: 'Meu Campo',
+  helpText: 'Texto de ajuda para preencher o campo',
+  endAdornment: <Icon icon="cog" />,
+  hasError: true,
 }

--- a/styleguide/src/Forms/Input/Input.stories.tsx
+++ b/styleguide/src/Forms/Input/Input.stories.tsx
@@ -24,58 +24,58 @@ Error.args = {
   errorMessage: 'Campo obrigatório',
 }
 
-export const StartAdornment = Template.bind({})
-StartAdornment.args = {
+export const Prefix = Template.bind({})
+Prefix.args = {
   label: 'Meu Campo',
   helpText: 'Texto de ajuda para preencher o campo',
-  startAdornment: 'R$',
+  prefix: 'R$',
 }
 
-export const IconStartAdornment = Template.bind({})
-IconStartAdornment.args = {
+export const IconPrefix = Template.bind({})
+IconPrefix.args = {
   label: 'Meu Campo',
   helpText: 'Texto de ajuda para preencher o campo',
-  startAdornment: <Icon icon="cog" />,
+  prefix: <Icon icon="cog" />,
   hasError: true,
 }
 
-export const EndAdornment = Template.bind({})
-EndAdornment.args = {
+export const Sufix = Template.bind({})
+Sufix.args = {
   label: 'Meu Campo',
   helpText: 'Texto de ajuda para preencher o campo',
-  endAdornment: 'R$',
+  sufix: 'R$',
 }
 
-export const IconEndAdornment = Template.bind({})
-IconEndAdornment.args = {
+export const IconSufix = Template.bind({})
+IconSufix.args = {
   label: 'Meu Campo',
   helpText: 'Texto de ajuda para preencher o campo',
-  endAdornment: <Icon icon="cog" />,
+  sufix: <Icon icon="cog" />,
   hasError: true,
 }
 
-export const StartAdornmentDisabled = Template.bind({})
-StartAdornmentDisabled.args = {
+export const PrefixDisabled = Template.bind({})
+PrefixDisabled.args = {
   label: 'Meu Campo',
   helpText: 'Texto de ajuda para preencher o campo',
-  startAdornment: 'R$',
+  prefix: 'R$',
   disabled: true,
   value: '123',
 }
 
-export const StartAdornmentReadOnly = Template.bind({})
-StartAdornmentReadOnly.args = {
+export const PrefixReadOnly = Template.bind({})
+PrefixReadOnly.args = {
   label: 'Meu Campo',
   helpText: 'Texto de ajuda para preencher o campo',
-  startAdornment: 'R$',
+  prefix: 'R$',
   readOnly: true,
   value: '123',
 }
 
-export const WithBothAdornment = Template.bind({})
-WithBothAdornment.args = {
+export const WithBoth = Template.bind({})
+WithBoth.args = {
   label: 'Meu Campo',
   helpText: 'Texto de ajuda para preencher o campo',
-  startAdornment: 'R$',
-  endAdornment: <Icon icon="cog" />,
+  prefix: 'R$',
+  sufix: <Icon icon="cog" />,
 }

--- a/styleguide/src/Forms/Input/Input.tsx
+++ b/styleguide/src/Forms/Input/Input.tsx
@@ -1,21 +1,17 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import { InputLabel, InputLabelProps } from '../InputLabel'
 import { InputHelpText, InputHelpTextProps } from '../InputHelpText'
 import {
-  inputDisabledClasses,
-  inputReadonlyClasses,
-  inputErrorClasses,
   inputDefaultClasses,
-  inputStartAdornmentClass,
-  inputEndAdornmentClass,
-  inputClasses,
+  inputContainerDisabledClasses,
+  inputContainerReadonlyClasses,
+  errorBorderClasses,
+  defaultBorderClasses,
+  inputContainerClasses,
   variantClasses,
   startAdornmentClasses,
   endAdornmentClasses,
-  adornmentFocusBorderClasses,
-  adornmentErrorBorderClasses,
-  adornmentDefaultBorderClasses,
 } from '../commonStyles'
 
 const InputComponent = (
@@ -34,8 +30,6 @@ const InputComponent = (
     type = 'text',
     startAdornment = undefined,
     endAdornment = undefined,
-    onFocus = undefined,
-    onBlur = undefined,
     ...props
   }: InputProps,
   ref: React.ForwardedRef<HTMLInputElement>
@@ -43,48 +37,30 @@ const InputComponent = (
   const inputId = id || name
   const hasErrorState = hasError || !!errorMessage
 
-  const defaultStartAdornmentClass = `${startAdornmentClasses} ${
+  const startAdornmentClass = `${startAdornmentClasses} ${
     variantClasses[variant]
-  } ${
-    hasErrorState ? adornmentErrorBorderClasses : adornmentDefaultBorderClasses
-  }`
-  const [startAdornmentClass, setStartAdornmentClass] = useState(
-    defaultStartAdornmentClass
-  )
+  } ${hasErrorState ? errorBorderClasses : ''}`
 
-  const defaultEndAdornmentClass = `${endAdornmentClasses} ${
+  const endAdornmentClass = `${endAdornmentClasses} ${
     variantClasses[variant]
-  } ${
-    hasErrorState ? adornmentErrorBorderClasses : adornmentDefaultBorderClasses
-  }`
-  const [endAdornmentClass, setEndAdornmentClass] = useState(
-    defaultEndAdornmentClass
-  )
+  } ${hasErrorState ? errorBorderClasses : ''}`
 
-  let inputClass = `${inputClasses} ${variantClasses[variant]}`
+  let inputContainerClass = `${inputContainerClasses} ${variantClasses[variant]}`
   if (disabled) {
-    inputClass += ` ${inputDefaultClasses} ${inputDisabledClasses}`
+    inputContainerClass += ` ${defaultBorderClasses} ${inputContainerDisabledClasses}`
   } else if (readOnly) {
-    inputClass += ` ${inputDefaultClasses} ${inputReadonlyClasses}`
+    inputContainerClass += ` ${defaultBorderClasses} ${inputContainerReadonlyClasses}`
   } else if (hasErrorState) {
-    inputClass += ` ${inputErrorClasses}`
+    inputContainerClass += ` ${errorBorderClasses}`
   } else {
-    inputClass += ` ${inputDefaultClasses}`
+    inputContainerClass += ` ${defaultBorderClasses}`
   }
 
-  if (startAdornment) {
-    if (hasErrorState) {
-      inputClass += ` ${inputStartAdornmentClass}`
-    } else {
-      inputClass += ` ${inputStartAdornmentClass} ${inputDefaultClasses}`
-    }
-  } else if (endAdornment) {
-    if (hasErrorState) {
-      inputClass += ` ${inputEndAdornmentClass}`
-    } else {
-      inputClass += ` ${inputEndAdornmentClass} ${inputDefaultClasses}`
-    }
-  }
+  const inputClass = `${inputDefaultClasses} ${
+    hasErrorState ? errorBorderClasses : defaultBorderClasses
+  } ${startAdornment ? 'border-l' : ''} ${endAdornment ? 'border-r' : ''} ${
+    variantClasses[variant]
+  }`
 
   const LabelComponent = (
     <InputLabel
@@ -104,34 +80,12 @@ const InputComponent = (
     />
   )
 
-  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
-    if (startAdornment) {
-      setStartAdornmentClass(
-        `${defaultStartAdornmentClass} ${adornmentFocusBorderClasses}`
-      )
-    } else if (endAdornment) {
-      setEndAdornmentClass(
-        `${defaultEndAdornmentClass} ${adornmentFocusBorderClasses}`
-      )
-    }
-    onFocus && onFocus(e)
-  }
-
-  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    if (startAdornment) {
-      setStartAdornmentClass(`${defaultStartAdornmentClass}`)
-    } else if (endAdornment) {
-      setEndAdornmentClass(`${defaultEndAdornmentClass}`)
-    }
-    onBlur && onBlur(e)
-  }
-
   return (
     <div className={`form-group flex flex-col ${className}`}>
       {LabelComponent}
-      <div className="flex w-full">
+      <div className={inputContainerClass}>
         {startAdornment && (
-          <div className={startAdornmentClass}>{startAdornment}</div>
+          <span className={startAdornmentClass}>{startAdornment}</span>
         )}
         <input
           ref={ref}
@@ -142,14 +96,13 @@ const InputComponent = (
           disabled={disabled}
           readOnly={readOnly}
           className={inputClass}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
           {...props}
         />
         {endAdornment && (
           <div className={endAdornmentClass}>{endAdornment}</div>
         )}
       </div>
+
       {HelpTextComponent}
     </div>
   )

--- a/styleguide/src/Forms/Input/Input.tsx
+++ b/styleguide/src/Forms/Input/Input.tsx
@@ -28,8 +28,8 @@ const InputComponent = (
     disabled,
     readOnly,
     type = 'text',
-    startAdornment = undefined,
-    endAdornment = undefined,
+    startAdornment,
+    endAdornment,
     ...props
   }: InputProps,
   ref: React.ForwardedRef<HTMLInputElement>

--- a/styleguide/src/Forms/Input/Input.tsx
+++ b/styleguide/src/Forms/Input/Input.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { InputLabel, InputLabelProps } from '../InputLabel'
 import { InputHelpText, InputHelpTextProps } from '../InputHelpText'
 import {
-  inputDefaultClasses,
   inputContainerDisabledClasses,
   inputContainerReadonlyClasses,
   errorBorderClasses,
@@ -12,6 +11,7 @@ import {
   variantClasses,
   startAdornmentClasses,
   endAdornmentClasses,
+  focusClass,
 } from '../commonStyles'
 
 const InputComponent = (
@@ -56,7 +56,7 @@ const InputComponent = (
     inputContainerClass += ` ${defaultBorderClasses}`
   }
 
-  const inputClass = `${inputDefaultClasses} ${
+  const inputClass = `w-full px-4 appearance-none shadow-none outline-none  bg-transparent -mt-px box-border ${focusClass} ${
     hasErrorState ? errorBorderClasses : defaultBorderClasses
   } ${startAdornment ? 'border-l' : ''} ${endAdornment ? 'border-r' : ''} ${
     variantClasses[variant]

--- a/styleguide/src/Forms/Input/Input.tsx
+++ b/styleguide/src/Forms/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { InputLabel, InputLabelProps } from '../InputLabel'
 import { InputHelpText, InputHelpTextProps } from '../InputHelpText'
@@ -7,8 +7,15 @@ import {
   inputReadonlyClasses,
   inputErrorClasses,
   inputDefaultClasses,
+  inputStartAdornmentClass,
+  inputEndAdornmentClass,
   inputClasses,
   variantClasses,
+  startAdornmentClasses,
+  endAdornmentClasses,
+  adornmentFocusBorderClasses,
+  adornmentErrorBorderClasses,
+  adornmentDefaultBorderClasses,
 } from '../commonStyles'
 
 const InputComponent = (
@@ -25,12 +32,34 @@ const InputComponent = (
     disabled,
     readOnly,
     type = 'text',
+    startAdornment = undefined,
+    endAdornment = undefined,
+    onFocus = undefined,
+    onBlur = undefined,
     ...props
   }: InputProps,
   ref: React.ForwardedRef<HTMLInputElement>
 ) => {
   const inputId = id || name
   const hasErrorState = hasError || !!errorMessage
+
+  const defaultStartAdornmentClass = `${startAdornmentClasses} ${
+    variantClasses[variant]
+  } ${
+    hasErrorState ? adornmentErrorBorderClasses : adornmentDefaultBorderClasses
+  }`
+  const [startAdornmentClass, setStartAdornmentClass] = useState(
+    defaultStartAdornmentClass
+  )
+
+  const defaultEndAdornmentClass = `${endAdornmentClasses} ${
+    variantClasses[variant]
+  } ${
+    hasErrorState ? adornmentErrorBorderClasses : adornmentDefaultBorderClasses
+  }`
+  const [endAdornmentClass, setEndAdornmentClass] = useState(
+    defaultEndAdornmentClass
+  )
 
   let inputClass = `${inputClasses} ${variantClasses[variant]}`
   if (disabled) {
@@ -41,6 +70,20 @@ const InputComponent = (
     inputClass += ` ${inputErrorClasses}`
   } else {
     inputClass += ` ${inputDefaultClasses}`
+  }
+
+  if (startAdornment) {
+    if (hasErrorState) {
+      inputClass += ` ${inputStartAdornmentClass}`
+    } else {
+      inputClass += ` ${inputStartAdornmentClass} ${inputDefaultClasses}`
+    }
+  } else if (endAdornment) {
+    if (hasErrorState) {
+      inputClass += ` ${inputEndAdornmentClass}`
+    } else {
+      inputClass += ` ${inputEndAdornmentClass} ${inputDefaultClasses}`
+    }
   }
 
   const LabelComponent = (
@@ -61,10 +104,35 @@ const InputComponent = (
     />
   )
 
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (startAdornment) {
+      setStartAdornmentClass(
+        `${defaultStartAdornmentClass} ${adornmentFocusBorderClasses}`
+      )
+    } else if (endAdornment) {
+      setEndAdornmentClass(
+        `${defaultEndAdornmentClass} ${adornmentFocusBorderClasses}`
+      )
+    }
+    onFocus && onFocus(e)
+  }
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (startAdornment) {
+      setStartAdornmentClass(`${defaultStartAdornmentClass}`)
+    } else if (endAdornment) {
+      setEndAdornmentClass(`${defaultEndAdornmentClass}`)
+    }
+    onBlur && onBlur(e)
+  }
+
   return (
     <div className={`form-group flex flex-col ${className}`}>
       {LabelComponent}
       <div className="flex w-full">
+        {startAdornment && (
+          <div className={startAdornmentClass}>{startAdornment}</div>
+        )}
         <input
           ref={ref}
           type={type}
@@ -74,8 +142,13 @@ const InputComponent = (
           disabled={disabled}
           readOnly={readOnly}
           className={inputClass}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           {...props}
         />
+        {endAdornment && (
+          <div className={endAdornmentClass}>{endAdornment}</div>
+        )}
       </div>
       {HelpTextComponent}
     </div>
@@ -101,4 +174,12 @@ export interface InputProps
    * Error message to display
    * */
   errorMessage?: string
+  /**
+   * Custom element to append at the start of input
+   * */
+  startAdornment?: React.ReactNode | string
+  /**
+   * Custom element to append at the end of input
+   * */
+  endAdornment?: React.ReactNode | string
 }

--- a/styleguide/src/Forms/Input/Input.tsx
+++ b/styleguide/src/Forms/Input/Input.tsx
@@ -99,7 +99,7 @@ const InputComponent = (
           {...props}
         />
         {endAdornment && (
-          <div className={endAdornmentClass}>{endAdornment}</div>
+          <span className={endAdornmentClass}>{endAdornment}</span>
         )}
       </div>
 

--- a/styleguide/src/Forms/Input/Input.tsx
+++ b/styleguide/src/Forms/Input/Input.tsx
@@ -9,8 +9,8 @@ import {
   defaultBorderClasses,
   inputContainerClasses,
   variantClasses,
-  startAdornmentClasses,
-  endAdornmentClasses,
+  prefixClasses,
+  sufixClasses,
   focusClass,
 } from '../commonStyles'
 
@@ -28,8 +28,8 @@ const InputComponent = (
     disabled,
     readOnly,
     type = 'text',
-    startAdornment,
-    endAdornment,
+    prefix,
+    sufix,
     ...props
   }: InputProps,
   ref: React.ForwardedRef<HTMLInputElement>
@@ -37,13 +37,13 @@ const InputComponent = (
   const inputId = id || name
   const hasErrorState = hasError || !!errorMessage
 
-  const startAdornmentClass = `${startAdornmentClasses} ${
-    variantClasses[variant]
-  } ${hasErrorState ? errorBorderClasses : ''}`
+  const prefixClass = `${prefixClasses} ${variantClasses[variant]} ${
+    hasErrorState ? errorBorderClasses : ''
+  }`
 
-  const endAdornmentClass = `${endAdornmentClasses} ${
-    variantClasses[variant]
-  } ${hasErrorState ? errorBorderClasses : ''}`
+  const sufixClass = `${sufixClasses} ${variantClasses[variant]} ${
+    hasErrorState ? errorBorderClasses : ''
+  }`
 
   let inputContainerClass = `${inputContainerClasses} ${variantClasses[variant]}`
   if (disabled) {
@@ -58,7 +58,7 @@ const InputComponent = (
 
   const inputClass = `w-full px-4 appearance-none shadow-none outline-none  bg-transparent -mt-px box-border ${focusClass} ${
     hasErrorState ? errorBorderClasses : defaultBorderClasses
-  } ${startAdornment ? 'border-l' : ''} ${endAdornment ? 'border-r' : ''} ${
+  } ${prefix ? 'border-l' : ''} ${sufix ? 'border-r' : ''} ${
     variantClasses[variant]
   }`
 
@@ -84,9 +84,7 @@ const InputComponent = (
     <div className={`form-group flex flex-col ${className}`}>
       {LabelComponent}
       <div className={inputContainerClass}>
-        {startAdornment && (
-          <span className={startAdornmentClass}>{startAdornment}</span>
-        )}
+        {prefix && <span className={prefixClass}>{prefix}</span>}
         <input
           ref={ref}
           type={type}
@@ -98,9 +96,7 @@ const InputComponent = (
           className={inputClass}
           {...props}
         />
-        {endAdornment && (
-          <span className={endAdornmentClass}>{endAdornment}</span>
-        )}
+        {sufix && <span className={sufixClass}>{sufix}</span>}
       </div>
 
       {HelpTextComponent}
@@ -114,7 +110,7 @@ export const Input = React.memo(InputWithFowardRef)
 export interface InputProps
   extends InputLabelProps,
     InputHelpTextProps,
-    React.InputHTMLAttributes<HTMLInputElement> {
+    Omit<React.InputHTMLAttributes<HTMLInputElement>, 'prefix'> {
   /**
    * Custom class name
    * */
@@ -130,9 +126,9 @@ export interface InputProps
   /**
    * Custom element to append at the start of input
    * */
-  startAdornment?: React.ReactNode | string
+  prefix?: React.ReactNode | string | null
   /**
    * Custom element to append at the end of input
    * */
-  endAdornment?: React.ReactNode | string
+  sufix?: React.ReactNode | string | null
 }

--- a/styleguide/src/Forms/InputCurrency/InputCurrency.stories.tsx
+++ b/styleguide/src/Forms/InputCurrency/InputCurrency.stories.tsx
@@ -41,5 +41,5 @@ OnFocusWithStartAdornment.args = {
   onFocus: (_event, value, _maskedValue) => {
     console.log(value)
   },
-  startAdornment: 'R$',
+  prefix: 'R$',
 }

--- a/styleguide/src/Forms/InputCurrency/InputCurrency.stories.tsx
+++ b/styleguide/src/Forms/InputCurrency/InputCurrency.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Story, Meta } from '@storybook/react'
-
 import { InputCurrency, InputCurrencyProps } from '.'
 
 export default {
@@ -8,29 +7,39 @@ export default {
   component: InputCurrency,
   args: {
     label: 'Currency Input',
-    currency: 'BRL'
+    currency: 'BRL',
   },
 } as Meta
 
-const Template: Story<InputCurrencyProps> = args => <InputCurrency {...args} />
+const Template: Story<InputCurrencyProps> = (args) => (
+  <InputCurrency {...args} />
+)
 
 export const Default = Template.bind({})
 
 export const MaxValue = Template.bind({})
 MaxValue.args = {
   helpText: 'Valor máximo R$ 2.000,00',
-  max: 2000
+  max: 2000,
 }
 
 export const CurrencyUSD = Template.bind({})
 CurrencyUSD.args = {
   currency: 'USD',
-  defaultValue: 1234.56
+  defaultValue: 1234.56,
 }
 
 export const OnChange = Template.bind({})
 OnChange.args = {
   onChange: (_event, value, _maskedValue) => {
     console.log(value)
-  }
+  },
+}
+
+export const OnFocusWithStartAdornment = Template.bind({})
+OnFocusWithStartAdornment.args = {
+  onFocus: (_event, value, _maskedValue) => {
+    console.log(value)
+  },
+  startAdornment: 'R$',
 }

--- a/styleguide/src/Forms/InputMask/InputMask.stories.tsx
+++ b/styleguide/src/Forms/InputMask/InputMask.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Story, Meta } from '@storybook/react'
 
 import { InputMask, InputMaskProps } from '.'
+import { Icon } from '../../Icons'
 
 export default {
   title: 'Forms/InputMask',
@@ -11,21 +12,11 @@ export default {
   },
 } as Meta
 
-const Template: Story<InputMaskProps> = args => <InputMask {...args} />
+const Template: Story<InputMaskProps> = (args) => <InputMask {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  mask: [
-    /\d/,
-    /\d/,
-    /\d/,
-    /\d/,
-    /\d/,
-    '-',
-    /\d/,
-    /\d/,
-    /\d/,
-  ]
+  mask: [/\d/, /\d/, /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/],
 }
 
 export const Date = Template.bind({})
@@ -37,4 +28,18 @@ Date.args = {
 export const OnlyNumbers = Template.bind({})
 OnlyNumbers.args = {
   formatValue: 'onlyNumber',
+}
+
+export const DateWithStartAdornment = Template.bind({})
+DateWithStartAdornment.args = {
+  formatValue: 'date',
+  defaultValue: '10/11/1990',
+  startAdornment: <Icon icon="clock" />,
+}
+
+export const DateWithEndAdornment = Template.bind({})
+DateWithEndAdornment.args = {
+  formatValue: 'date',
+  defaultValue: '10/11/1990',
+  endAdornment: <Icon icon="clock" />,
 }

--- a/styleguide/src/Forms/InputMask/InputMask.stories.tsx
+++ b/styleguide/src/Forms/InputMask/InputMask.stories.tsx
@@ -34,20 +34,20 @@ export const DateWithStartAdornment = Template.bind({})
 DateWithStartAdornment.args = {
   formatValue: 'date',
   defaultValue: '10/11/1990',
-  startAdornment: <Icon icon="clock" />,
+  prefix: <Icon icon="clock" />,
 }
 
 export const DateWithEndAdornment = Template.bind({})
 DateWithEndAdornment.args = {
   formatValue: 'date',
   defaultValue: '10/11/1990',
-  endAdornment: <Icon icon="clock" />,
+  sufix: <Icon icon="clock" />,
 }
 
 export const DateWithEndAdornmentError = Template.bind({})
 DateWithEndAdornmentError.args = {
   formatValue: 'date',
   defaultValue: '10/11/1990',
-  endAdornment: <Icon icon="clock" />,
+  sufix: <Icon icon="clock" />,
   hasError: true,
 }

--- a/styleguide/src/Forms/InputMask/InputMask.stories.tsx
+++ b/styleguide/src/Forms/InputMask/InputMask.stories.tsx
@@ -43,3 +43,11 @@ DateWithEndAdornment.args = {
   defaultValue: '10/11/1990',
   endAdornment: <Icon icon="clock" />,
 }
+
+export const DateWithEndAdornmentError = Template.bind({})
+DateWithEndAdornmentError.args = {
+  formatValue: 'date',
+  defaultValue: '10/11/1990',
+  endAdornment: <Icon icon="clock" />,
+  hasError: true,
+}

--- a/styleguide/src/Forms/InputMask/InputMask.tsx
+++ b/styleguide/src/Forms/InputMask/InputMask.tsx
@@ -8,7 +8,7 @@ import { Input, InputProps } from '../Input'
 import { formatValuePatterns } from './utils'
 
 function InputMaskComponent(
-  { formatValue = 'default', ...props }: InputMaskProps,
+  { formatValue = 'default', prefix, ...props }: InputMaskProps,
   inputRef: React.ForwardedRef<HTMLInputElement>
 ) {
   const renderInput = (ref: (inputElement: HTMLElement) => void, p: any) => {
@@ -24,7 +24,13 @@ function InputMaskComponent(
     mergedProps.mask = false
   }
 
-  return <ReactTextMask render={renderInput} {...mergedProps} />
+  return (
+    <ReactTextMask
+      render={renderInput}
+      {...mergedProps}
+      prefix={prefix as string}
+    />
+  )
 }
 
 export const InputMask = React.forwardRef(InputMaskComponent)

--- a/styleguide/src/Forms/Select/Select.tsx
+++ b/styleguide/src/Forms/Select/Select.tsx
@@ -3,9 +3,9 @@ import React from 'react'
 import { InputLabel, InputLabelProps } from '../InputLabel'
 import { InputHelpText, InputHelpTextProps } from '../InputHelpText'
 import {
-  inputDisabledClasses,
-  inputErrorClasses,
-  inputDefaultClasses,
+  inputContainerDisabledClasses,
+  errorBorderClasses,
+  defaultBorderClasses,
   inputClasses,
   variantClasses,
 } from '../commonStyles'
@@ -43,11 +43,11 @@ export const SelectComponent = (
   } else {
     inputClass = `${inputClasses} ${selectClasses} ${variantClasses[variant]}`
     if (disabled) {
-      inputClass += ` ${inputDefaultClasses} ${inputDisabledClasses}`
+      inputClass += ` ${defaultBorderClasses} ${inputContainerDisabledClasses}`
     } else if (hasErrorState) {
-      inputClass += ` ${inputErrorClasses}`
+      inputClass += ` ${errorBorderClasses}`
     } else {
-      inputClass += ` ${inputDefaultClasses}`
+      inputClass += ` ${defaultBorderClasses}`
     }
   }
 

--- a/styleguide/src/Forms/commonStyles.ts
+++ b/styleguide/src/Forms/commonStyles.ts
@@ -9,8 +9,9 @@ export const errorBorderClasses = 'border-danger focus:border-danger'
 
 export const defaultBorderClasses = 'border-card-stroke'
 
-export const inputDefaultClasses =
-  'w-full px-4 appearance-none shadow-none outline-none  bg-transparent -mt-px box-border focus:border-inverted-1'
+export const focusClass = 'focus:border-inverted-1'
+  
+export const inputClasses = `appearance-none shadow-none outline-none bg-base-1 border px-4 rounded text-on-base text-sm tracking-4 min-w-0 w-full transition-border duration-75 ${focusClass} ${inputPlaceholderClasses}`
 
 export const inputContainerClasses = `flex w-full focus-within:border-inverted-1 bg-base-1 border rounded text-on-base text-sm tracking-4 min-w-0 w-full transition-border duration-75 ${inputPlaceholderClasses}`
 

--- a/styleguide/src/Forms/commonStyles.ts
+++ b/styleguide/src/Forms/commonStyles.ts
@@ -17,9 +17,9 @@ export const inputContainerClasses = `flex w-full focus-within:border-inverted-1
 
 const adornmentClasses = `flex justify-center items-center relative w-16 text-f6 text-inverted-2 tracking-4`
 
-export const startAdornmentClasses = `${adornmentClasses} rounded-l left-0`
+export const prefixClasses = `${adornmentClasses} rounded-l left-0`
 
-export const endAdornmentClasses = `${adornmentClasses} rounded-r right-0`
+export const sufixClasses = `${adornmentClasses} rounded-r right-0`
 
 export const variantClasses = {
   default: 'h-12',

--- a/styleguide/src/Forms/commonStyles.ts
+++ b/styleguide/src/Forms/commonStyles.ts
@@ -1,33 +1,24 @@
 export const inputPlaceholderClasses = 'placeholder-on-base-2'
 
-export const inputDisabledClasses =
+export const inputContainerDisabledClasses =
   'bg-base-3 pointer-events-none text-on-base-2'
 
-export const inputReadonlyClasses = 'bg-base-2'
+export const inputContainerReadonlyClasses = 'bg-base-2'
 
-export const inputErrorClasses = 'border-danger focus:border-danger'
+export const errorBorderClasses = 'border-danger focus:border-danger'
 
-export const inputDefaultClasses = 'border-card-stroke'
+export const defaultBorderClasses = 'border-card-stroke'
 
-export const inputFocusClasses = 'focus:border-inverted-1'
+export const inputDefaultClasses =
+  'w-full px-4 appearance-none shadow-none outline-none  bg-transparent -mt-px box-border focus:border-inverted-1'
 
-export const inputClasses = `appearance-none shadow-none outline-none bg-base-1 border px-4 rounded text-on-base text-sm tracking-4 min-w-0 w-full transition-border duration-75 ${inputFocusClasses} ${inputPlaceholderClasses}`
+export const inputContainerClasses = `flex w-full focus-within:border-inverted-1 bg-base-1 border rounded text-on-base text-sm tracking-4 min-w-0 w-full transition-border duration-75 ${inputPlaceholderClasses}`
 
-export const inputStartAdornmentClass = `border-l-0 rounded-l-none`
+const adornmentClasses = `flex justify-center items-center relative w-16 text-f6 text-inverted-2 tracking-4`
 
-export const inputEndAdornmentClass = `border-r-0 rounded-r-none`
+export const startAdornmentClasses = `${adornmentClasses} rounded-l left-0`
 
-export const adornmentDefaultBorderClasses = 'border-card-stroke'
-
-export const adornmentFocusBorderClasses = 'border-inverted-1'
-
-export const adornmentErrorBorderClasses = 'border-danger'
-
-const adornmentClass = `flex justify-center items-center relative w-16 border text-f6 text-inverted-2 tracking-4`
-
-export const startAdornmentClasses = `${adornmentClass} rounded-l left-0`
-
-export const endAdornmentClasses = `${adornmentClass} rounded-r right-0`
+export const endAdornmentClasses = `${adornmentClasses} rounded-r right-0`
 
 export const variantClasses = {
   default: 'h-12',

--- a/styleguide/src/Forms/commonStyles.ts
+++ b/styleguide/src/Forms/commonStyles.ts
@@ -13,6 +13,22 @@ export const inputFocusClasses = 'focus:border-inverted-1'
 
 export const inputClasses = `appearance-none shadow-none outline-none bg-base-1 border px-4 rounded text-on-base text-sm tracking-4 min-w-0 w-full transition-border duration-75 ${inputFocusClasses} ${inputPlaceholderClasses}`
 
+export const inputStartAdornmentClass = `border-l-0 rounded-l-none`
+
+export const inputEndAdornmentClass = `border-r-0 rounded-r-none`
+
+export const adornmentDefaultBorderClasses = 'border-card-stroke'
+
+export const adornmentFocusBorderClasses = 'border-inverted-1'
+
+export const adornmentErrorBorderClasses = 'border-danger'
+
+const adornmentClass = `flex justify-center items-center relative w-16 border text-f6 text-inverted-2 tracking-4`
+
+export const startAdornmentClasses = `${adornmentClass} rounded-l left-0`
+
+export const endAdornmentClasses = `${adornmentClass} rounded-r right-0`
+
 export const variantClasses = {
   default: 'h-12',
   small: 'h-8',

--- a/styleguide/src/Forms/commonStyles.ts
+++ b/styleguide/src/Forms/commonStyles.ts
@@ -10,7 +10,7 @@ export const errorBorderClasses = 'border-danger focus:border-danger'
 export const defaultBorderClasses = 'border-card-stroke'
 
 export const focusClass = 'focus:border-inverted-1'
-  
+
 export const inputClasses = `appearance-none shadow-none outline-none bg-base-1 border px-4 rounded text-on-base text-sm tracking-4 min-w-0 w-full transition-border duration-75 ${focusClass} ${inputPlaceholderClasses}`
 
 export const inputContainerClasses = `flex w-full focus-within:border-inverted-1 bg-base-1 border rounded text-on-base text-sm tracking-4 min-w-0 w-full transition-border duration-75 ${inputPlaceholderClasses}`


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adicionar as props opcionais para poder adicionar um elemento de sufixo ou prefixo num campo de texto.

#### What problem is this solving?

Resolve o problema que os inputs atuais não possuíam essa opção, por exemplo : input de dinheiro não tinha o cifrão na frente com sufixo

#### How should this be manually tested?
pode ser testado adicionando a propriedade `startAdornment` ou `endAdornment` a um input, tanto string quanto um html/icone
já deixei alguns exemplos na maiorias dos inputs

<img width="1133" alt="Captura de Tela 2021-09-01 às 18 45 42" src="https://user-images.githubusercontent.com/36740164/131749524-30fb1a99-d888-4fd9-8d15-57a9f83af074.png">

#### Screenshots or example usage
<img width="999" alt="Captura de Tela 2021-09-01 às 18 47 11" src="https://user-images.githubusercontent.com/36740164/131749826-56645a23-9540-436a-a370-13208b739562.png">
<img width="1052" alt="Captura de Tela 2021-09-01 às 18 47 17" src="https://user-images.githubusercontent.com/36740164/131749833-8daef815-7d58-4e35-9b5d-dd644754246f.png">
<img width="1001" alt="Captura de Tela 2021-09-01 às 18 48 23" src="https://user-images.githubusercontent.com/36740164/131749840-3b439924-142f-4983-a1b2-75a52ef30e33.png">

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
