### PR TITLE
feat: add black and focus colors in tailwind

### DIFF
--- a/tailwindcss/src/defaultPreset.js
+++ b/tailwindcss/src/defaultPreset.js
@@ -5,6 +5,7 @@ module.exports = {
       "current": "currentColor",
       "transparent": "transparent",
       "black-alpha": "rgba(0, 0, 0,.25)",
+      "black": "#000000",
 
       "base-1": "#FFFFFF",
       "base-2": "#F8F8F9",
@@ -69,7 +70,9 @@ module.exports = {
 
       "card-stroke": "#CED4D8",
       "card-stroke-2": "#A3AAB5",
-      "card-shadow": "#E1E4E7"
+      "card-shadow": "#E1E4E7",
+
+      "focus": "#5690F7"
     },
     "extend": {
       "boxShadow": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adiciona 2 novas cores ao preset do Tailwind:
- focus: `#5690F7`
- black: `#000000`

#### What problem is this solving?

Cores faltando.

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
