### PR TITLE
fix: class refinement and checkbox label allow node

### DIFF
--- a/styleguide/src/Forms/Checkbox/Checkbox.spec.tsx
+++ b/styleguide/src/Forms/Checkbox/Checkbox.spec.tsx
@@ -8,7 +8,7 @@ const { Default, Disabled, DisabledChecked } = composeStories(stories)
 describe('Checkbox tests', () => {
   it('Default', () => {
     mount(<Default />)
-    cy.get('.input-label').contains('Meu checkbox')
+    cy.get('.input-label').contains('Li e aceito os termos de uso.')
     cy.get('input').should('have.attr', 'type', 'checkbox')
   })
 

--- a/styleguide/src/Forms/Checkbox/Checkbox.stories.tsx
+++ b/styleguide/src/Forms/Checkbox/Checkbox.stories.tsx
@@ -8,11 +8,25 @@ export default {
   component: Checkbox,
 } as Meta
 
+const labelCheckbox = (
+  <>
+    <span>Li e aceito os </span>
+    <a href="/terms" target="_blank" rel="noopener noreferrer" className="text-primary hover:text-primary-dark transition-colors font-semibold">
+      termos de uso.
+    </a>
+  </>
+)
+
 const Template: Story<CheckboxProps> = (args) => <Checkbox {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  label: 'Meu checkbox',
+  label: labelCheckbox,
+}
+
+export const Indeterminate = Template.bind({})
+Indeterminate.args = {
+  label: "Meu checkbox",
   indeterminate: true,
 }
 

--- a/styleguide/src/Forms/Checkbox/Checkbox.tsx
+++ b/styleguide/src/Forms/Checkbox/Checkbox.tsx
@@ -52,7 +52,10 @@ const CheckboxComponent = (
   const checkboxLabelClasses = `ml-1 input-label text-f6 tracking-4 leading-6`
 
   return (
-    <label htmlFor={inputId} className="inline-flex items-center cursor-pointer">
+    <label
+      htmlFor={inputId}
+      className="inline-flex items-center cursor-pointer"
+    >
       <span className="rounded z-50 flex items-center justify-center focus-within:ring-2 ring-focus">
         <input
           ref={ref || inputRef}

--- a/styleguide/src/Forms/Checkbox/Checkbox.tsx
+++ b/styleguide/src/Forms/Checkbox/Checkbox.tsx
@@ -49,11 +49,11 @@ const CheckboxComponent = (
       : 'bg-base-1'
   }  rounded w-4 h-4 flex justify-center items-center m-px`
 
-  const checkboxLabelClasses = `ml-2 duration-200 transition ease-out input-label`
+  const checkboxLabelClasses = `ml-1 input-label text-f6 tracking-4 leading-6`
 
   return (
-    <label htmlFor={inputId} className="flex items-center cursor-pointer">
-      <span className="border-2 rounded-md border-transparent z-50 flex items-center justify-center focus-within:border-focus">
+    <label htmlFor={inputId} className="inline-flex items-center cursor-pointer">
+      <span className="rounded z-50 flex items-center justify-center focus-within:ring-2 ring-focus">
         <input
           ref={ref || inputRef}
           type="checkbox"
@@ -103,6 +103,6 @@ export const Checkbox = React.memo(CheckboxWithFowardRef)
 
 export interface CheckboxProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
-  label?: string
+  label?: string | React.ReactNode
   indeterminate?: boolean
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Permitir conteúdo html dentro da label do checkbox, e ajeitar algumas classes.

#### What problem is this solving?

Label só aceitava string e precisamos de um `<a>` pra checkbox de termos de uso.

#### How should this be manually tested?

[Figma](https://www.figma.com/file/Z2WDD4SH8zwaJC2K5wbtMO/Sistema-Integrado?node-id=95%3A6365)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/7097946/134597973-c63b2495-642a-40f1-853d-55228408ce9d.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
