### PR TITLE
Suffix should have same height as parent

### DIFF
--- a/styleguide/src/Forms/commonStyles.ts
+++ b/styleguide/src/Forms/commonStyles.ts
@@ -15,7 +15,7 @@ export const inputClasses = `appearance-none shadow-none outline-none bg-base-1 
 
 export const inputContainerClasses = `flex w-full focus-within:border-inverted-1 bg-base-1 border rounded text-on-base text-sm tracking-4 min-w-0 w-full transition-border duration-75 ${inputPlaceholderClasses}`
 
-const adornmentClasses = `flex justify-center items-center relative w-16 text-f6 text-inverted-2 tracking-4`
+const adornmentClasses = `flex justify-center items-center relative w-16 text-f6 text-inverted-2 tracking-4 -mt-px`
 
 export const prefixClasses = `${adornmentClasses} rounded-l left-0`
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Sufix e PRefix estavam sem a margem top negativa, fazendo assim com que ele ficasse com uma altura maior que a div parent, causando problemas de posicionamento no layout.

#### What problem is this solving?
Suffix e Prefix com a mesma altura do seu respectivo container

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
