### PR TITLE
feat: onblur and default value for dropdown

### DIFF
--- a/styleguide/src/Forms/Dropdown/Dropdown.stories.tsx
+++ b/styleguide/src/Forms/Dropdown/Dropdown.stories.tsx
@@ -115,3 +115,17 @@ WithError.args = {
   label: 'Label',
   errorMessage: 'Houve um erro',
 }
+
+export const DefaultValue = Template.bind({})
+DefaultValue.args = {
+  placeholder: 'Selecione um item',
+  defaultValue: dropdownOptions[0],
+}
+
+export const OnBlur = Template.bind({})
+OnBlur.args = {
+  placeholder: 'Selecione um item',
+  onBlur: (e) => {
+    console.log(e)
+  },
+}

--- a/styleguide/src/Forms/Dropdown/Dropdown.stories.tsx
+++ b/styleguide/src/Forms/Dropdown/Dropdown.stories.tsx
@@ -129,3 +129,9 @@ OnBlur.args = {
     console.log(e)
   },
 }
+
+export const MaxMenuHeight = Template.bind({})
+MaxMenuHeight.args = {
+  placeholder: 'Selecione um item',
+  maxMenuHeight: 80,
+}

--- a/styleguide/src/Forms/Dropdown/Dropdown.tsx
+++ b/styleguide/src/Forms/Dropdown/Dropdown.tsx
@@ -157,6 +157,7 @@ const DropdownComponent = (
     defaultValue,
     maxMenuHeight = 300,
     menuPosition = 'absolute',
+    menuPlacement = 'auto',
   }: DropdownProps,
   ref: React.ForwardedRef<any>
 ) => {
@@ -185,6 +186,7 @@ const DropdownComponent = (
         maxMenuHeight={maxMenuHeight}
         menuPortalTarget={document.body}
         menuPosition={menuPosition}
+        menuPlacement={menuPlacement}
         styles={{
           option: () => {
             return {}
@@ -198,6 +200,9 @@ const DropdownComponent = (
               zIndex: 999,
               padding: 20,
             }
+          },
+          menuPortal: (base) => {
+            return { ...base, zIndex: 9999 }
           },
           indicatorSeparator: () => {
             return {}
@@ -305,6 +310,11 @@ export interface DropdownProps {
    * @default 'absolute'
    * */
   menuPosition?: 'fixed' | 'absolute'
+  /**
+   * Default placement of the menu in relation to the control. 'auto' will flip when there isn't enough space below the control.
+   * @default 'auto'
+   * */
+  menuPlacement?: 'top' | 'bottom' | 'auto'
   id?: string
   name?: string
 }

--- a/styleguide/src/Forms/Dropdown/Dropdown.tsx
+++ b/styleguide/src/Forms/Dropdown/Dropdown.tsx
@@ -184,7 +184,7 @@ const DropdownComponent = (
         defaultValue={defaultValue}
         formatGroupLabel={(data) => formatGroupLabel(data, showGroupLength)}
         maxMenuHeight={maxMenuHeight}
-        menuPortalTarget={document.body}
+        menuPortalTarget={document?.body}
         menuPosition={menuPosition}
         menuPlacement={menuPlacement}
         styles={{

--- a/styleguide/src/Forms/Dropdown/Dropdown.tsx
+++ b/styleguide/src/Forms/Dropdown/Dropdown.tsx
@@ -155,6 +155,7 @@ const DropdownComponent = (
     name,
     required = false,
     defaultValue,
+    maxMenuHeight = 300,
   }: DropdownProps,
   ref: React.ForwardedRef<any>
 ) => {
@@ -180,6 +181,7 @@ const DropdownComponent = (
         isDisabled={disabled}
         defaultValue={defaultValue}
         formatGroupLabel={(data) => formatGroupLabel(data, showGroupLength)}
+        maxMenuHeight={maxMenuHeight}
         styles={{
           option: () => {
             return {}
@@ -290,6 +292,10 @@ export interface DropdownProps {
    * Initial default value for the dropdown
    * */
   defaultValue?: CustomOptionProps
+  /**
+   * Max height for the options menu container
+   * */
+  maxMenuHeight?: number
   id?: string
   name?: string
 }

--- a/styleguide/src/Forms/Dropdown/Dropdown.tsx
+++ b/styleguide/src/Forms/Dropdown/Dropdown.tsx
@@ -156,6 +156,7 @@ const DropdownComponent = (
     required = false,
     defaultValue,
     maxMenuHeight = 300,
+    menuPosition = 'absolute',
   }: DropdownProps,
   ref: React.ForwardedRef<any>
 ) => {
@@ -182,6 +183,8 @@ const DropdownComponent = (
         defaultValue={defaultValue}
         formatGroupLabel={(data) => formatGroupLabel(data, showGroupLength)}
         maxMenuHeight={maxMenuHeight}
+        menuPortalTarget={document.body}
+        menuPosition={menuPosition}
         styles={{
           option: () => {
             return {}
@@ -192,6 +195,7 @@ const DropdownComponent = (
           menu: (base) => {
             return {
               ...base,
+              zIndex: 999,
               padding: 20,
             }
           },
@@ -296,6 +300,11 @@ export interface DropdownProps {
    * Max height for the options menu container
    * */
   maxMenuHeight?: number
+  /**
+   * The CSS position value of the menu, when "fixed" extra layout management is required
+   * @default 'absolute'
+   * */
+  menuPosition?: 'fixed' | 'absolute'
   id?: string
   name?: string
 }

--- a/styleguide/src/Forms/Dropdown/Dropdown.tsx
+++ b/styleguide/src/Forms/Dropdown/Dropdown.tsx
@@ -208,7 +208,7 @@ const DropdownComponent = (
         placeholder={placeholder}
         noOptionsMessage={() => emptyMessage}
         onChange={(value) => onChange && value && onChange(value)}
-        onBlur={(event) => onBlur && onBlur(event)}
+        onBlur={(event) => onBlur?.(event)}
         components={{
           Option: (props) => IconOption(props, markSelectedOption),
           DropdownIndicator: (props) => CustomDropdownIndicator(props),

--- a/styleguide/src/Forms/Dropdown/Dropdown.tsx
+++ b/styleguide/src/Forms/Dropdown/Dropdown.tsx
@@ -20,7 +20,7 @@ export const variantClasses = {
 }
 
 export interface CustomOptionProps {
-  value: string
+  value: string | number
   label: string
   icon?: string | undefined
   isDisabled?: boolean | undefined
@@ -141,6 +141,7 @@ const DropdownComponent = (
     placeholder,
     isSearchable = false,
     onChange,
+    onBlur,
     variant = 'default',
     markSelectedOption,
     fixedValue,
@@ -153,6 +154,7 @@ const DropdownComponent = (
     id,
     name,
     required = false,
+    defaultValue,
   }: DropdownProps,
   ref: React.ForwardedRef<any>
 ) => {
@@ -176,6 +178,7 @@ const DropdownComponent = (
         isSearchable={isSearchable}
         value={fixedValue}
         isDisabled={disabled}
+        defaultValue={defaultValue}
         formatGroupLabel={(data) => formatGroupLabel(data, showGroupLength)}
         styles={{
           option: () => {
@@ -203,6 +206,7 @@ const DropdownComponent = (
         placeholder={placeholder}
         noOptionsMessage={() => emptyMessage}
         onChange={(value) => onChange && value && onChange(value)}
+        onBlur={(event) => onBlur && onBlur(event)}
         components={{
           Option: (props) => IconOption(props, markSelectedOption),
           DropdownIndicator: (props) => CustomDropdownIndicator(props),
@@ -231,6 +235,7 @@ export interface DropdownProps {
   options: CustomOptionProps[] | CustomGroupedOptionsProps[]
   placeholder?: string
   onChange?: (option: CustomOptionProps) => void
+  onBlur?: (event: React.FocusEvent<HTMLElement>) => void
   /**
    * Changes the size of dropdown
    * @default default
@@ -281,6 +286,10 @@ export interface DropdownProps {
    * @default false
    * */
   required?: boolean
+  /**
+   * Initial default value for the dropdown
+   * */
+  defaultValue?: CustomOptionProps
   id?: string
   name?: string
 }

--- a/styleguide/src/Forms/Toggle/Toggle.tsx
+++ b/styleguide/src/Forms/Toggle/Toggle.tsx
@@ -33,24 +33,22 @@ const ToggleComponent = (
   const toggleLabelClasses = `ml-2 text-inverted-1 text-f6 tracking-4 label`
 
   return (
-    <div className="flex items-center justify-center w-full mb-12">
-      <label htmlFor={inputId} className={`flex items-center cursor-pointer`}>
-        <div className={`${toggleContainerDisabledClasses}`}>
-          <input
-            ref={ref}
-            type="checkbox"
-            id={inputId}
-            className="sr-only"
-            checked={isChecked}
-            onChange={handleChange}
-            {...props}
-          />
-          <div className={toggleBackgroundClasses}></div>
-          <div className={toggleCircleClasses}></div>
-        </div>
-        <div className={toggleLabelClasses}>{label}</div>
-      </label>
-    </div>
+    <label htmlFor={inputId} className={`flex items-center cursor-pointer`}>
+      <div className={`${toggleContainerDisabledClasses}`}>
+        <input
+          ref={ref}
+          type="checkbox"
+          id={inputId}
+          className="sr-only"
+          checked={isChecked}
+          onChange={handleChange}
+          {...props}
+        />
+        <div className={toggleBackgroundClasses}></div>
+        <div className={toggleCircleClasses}></div>
+      </div>
+      <div className={toggleLabelClasses}>{label}</div>
+    </label>
   )
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adicionar as props de onBlur, defaultValue e maxMenuHeight

#### What problem is this solving?

resolve o problema de não conseguir capturar o evento de onBlur para validações por exemplo e não poder setar um valor inicial para o dropdown, também o maxMenuHeight para poder personalizar o tamanho dos menus  com as opções do dropdown

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
