### PR TITLE
Adding suport for labelComplements for input components

### DIFF
--- a/styleguide/src/Forms/Dropdown/Dropdown.stories.tsx
+++ b/styleguide/src/Forms/Dropdown/Dropdown.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Story, Meta } from '@storybook/react'
 
 import { Dropdown, DropdownProps, CustomOptionProps } from './'
+import { Icon } from '../../Icons'
 
 const dropdownOptions = [
   { label: 'Visualizar 15', value: 15 },
@@ -134,4 +135,11 @@ export const MaxMenuHeight = Template.bind({})
 MaxMenuHeight.args = {
   placeholder: 'Selecione um item',
   maxMenuHeight: 80,
+}
+
+export const WithComplement = Template.bind({})
+WithComplement.args = {
+  label: 'Label',
+  labelComplement: <Icon icon="infoCircle" size={4} block />,
+  required: true,
 }

--- a/styleguide/src/Forms/Dropdown/Dropdown.tsx
+++ b/styleguide/src/Forms/Dropdown/Dropdown.tsx
@@ -10,7 +10,7 @@ import Select, {
 } from 'react-select'
 import { Icon as IconComponent } from '../../Icons'
 import { InputHelpText } from '../InputHelpText'
-import { InputLabel } from '../InputLabel'
+import { InputLabel, InputLabelProps } from '../InputLabel'
 
 export const variantClasses = {
   default: 'h-12',
@@ -151,6 +151,7 @@ const DropdownComponent = (
     errorMessage,
     helpText,
     label,
+    labelComplement,
     id,
     name,
     required = false,
@@ -166,6 +167,7 @@ const DropdownComponent = (
     <div>
       <InputLabel
         label={label}
+        labelComplement={labelComplement}
         required={required}
         hasError={!!errorMessage}
         htmlFor={inputId}
@@ -284,6 +286,7 @@ export interface DropdownProps {
    * Help text
    * */
   label?: string
+  labelComplement: InputLabelProps['labelComplement']
   /** Should display the label above the dropdown
    * @default ''
    * */

--- a/styleguide/src/Forms/Input/Input.stories.tsx
+++ b/styleguide/src/Forms/Input/Input.stories.tsx
@@ -91,3 +91,10 @@ WithBoth.args = {
   prefix: 'R$',
   sufix: <Icon icon="cog" />,
 }
+
+export const WithComplement = Template.bind({})
+WithComplement.args = {
+  label: 'Label',
+  labelComplement: <Icon icon="infoCircle" size={4} block />,
+  required: true,
+}

--- a/styleguide/src/Forms/Input/Input.tsx
+++ b/styleguide/src/Forms/Input/Input.tsx
@@ -18,6 +18,7 @@ const InputComponent = (
   {
     className = '',
     label,
+    labelComplement,
     helpText,
     hasError = false,
     errorMessage,
@@ -65,6 +66,7 @@ const InputComponent = (
   const LabelComponent = (
     <InputLabel
       label={label}
+      labelComplement={labelComplement}
       required={required}
       hasError={hasErrorState}
       htmlFor={inputId}

--- a/styleguide/src/Forms/Select/Select.stories.tsx
+++ b/styleguide/src/Forms/Select/Select.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Story, Meta } from '@storybook/react'
 
 import { Select, SelectProps } from '.'
+import { Icon } from '../../Icons'
 
 const selectOptions = [
   { label: 'Visualizar 15', value: 15 },
@@ -42,6 +43,14 @@ export const WithoutStyle = Template.bind({})
 WithoutStyle.args = {
   withoutStyle: true,
 }
+
+export const WithComplement = Template.bind({})
+WithComplement.args = {
+  label: 'Label',
+  labelComplement: <Icon icon="infoCircle" size={4} block />,
+  required: true,
+}
+
 
 export const Disabled = Template.bind({})
 Disabled.args = {

--- a/styleguide/src/Forms/Select/Select.tsx
+++ b/styleguide/src/Forms/Select/Select.tsx
@@ -16,6 +16,7 @@ export const SelectComponent = (
   {
     className = '',
     label,
+    labelComplement,
     helpText,
     hasError = false,
     errorMessage,
@@ -58,6 +59,7 @@ export const SelectComponent = (
       hasError={hasErrorState}
       htmlFor={selectId}
       className="mb-1"
+      labelComplement={labelComplement}
     />
   )
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Input components label also accept complement (used to display Icons or related inside label)

#### Screenshots or example usage
Dropbox:

![image](https://user-images.githubusercontent.com/91084028/136096417-b37dae18-49a5-438d-845e-663ed0abbcbe.png)

Select:

![image](https://user-images.githubusercontent.com/91084028/136096478-bfd2ac99-290b-4217-8a1a-3276425cc8e6.png)

Input:
![image](https://user-images.githubusercontent.com/91084028/136096538-d42c5495-edcb-4e6e-a84b-7907e456af51.png)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
