### PR TITLE
Alert subtitle accept reactNode and actions don't shrink

### DIFF
--- a/styleguide/src/Indicators/Alert/Alert.tsx
+++ b/styleguide/src/Indicators/Alert/Alert.tsx
@@ -76,7 +76,7 @@ const AlertComponent = ({
           {subtitle && <span className="alert-subtitle mt-1">{subtitle}</span>}
         </div>
         {actions && (
-          <div className="alert-actions flex items-center flex-row sm:flex-row-reverse sm:space-x-reverse space-x-3 mt-3 sm:mt-0 sm:ml-5">
+          <div className="alert-actions flex flex-shrink-0 items-center flex-row sm:flex-row-reverse sm:space-x-reverse space-x-3 mt-3 sm:mt-0 sm:ml-5">
             {actions}
           </div>
         )}
@@ -113,7 +113,7 @@ export interface AlertProps {
   /**
    * Alert text below title
    */
-  subtitle?: string
+  subtitle?: string | React.ReactNode
   /**
    * Function to close alert (also activate `showClose`)
    */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Alert subtitle accept reactNode and actions don't shrink

#### What problem is this solving?
- Allow send `<div>` inside `subtitle`
- Action buttons don't break inner text

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/3163867/140812187-cc968004-5a1c-461c-8e3f-c6ee9765ef03.png)
After:
![image](https://user-images.githubusercontent.com/3163867/140812268-53d44322-cd5c-4b02-bfd5-1b648a0e46e0.png)

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
