### PR TITLE
fix: toogle inline flex and box content class

### DIFF
--- a/styleguide/src/Forms/Toggle/Toggle.tsx
+++ b/styleguide/src/Forms/Toggle/Toggle.tsx
@@ -33,7 +33,7 @@ const ToggleComponent = (
   const toggleLabelClasses = `ml-2 text-inverted-1 text-f6 tracking-4 label`
 
   return (
-    <label htmlFor={inputId} className={`flex items-center cursor-pointer`}>
+    <label htmlFor={inputId} className={`inline-flex items-center cursor-pointer`}>
       <div className={`${toggleContainerDisabledClasses}`}>
         <input
           ref={ref}

--- a/styleguide/src/Forms/Toggle/Toggle.tsx
+++ b/styleguide/src/Forms/Toggle/Toggle.tsx
@@ -33,7 +33,10 @@ const ToggleComponent = (
   const toggleLabelClasses = `ml-2 text-inverted-1 text-f6 tracking-4 label`
 
   return (
-    <label htmlFor={inputId} className={`inline-flex items-center cursor-pointer`}>
+    <label
+      htmlFor={inputId}
+      className={`inline-flex items-center cursor-pointer`}
+    >
       <div className={`${toggleContainerDisabledClasses}`}>
         <input
           ref={ref}

--- a/styleguide/src/Layout/Box/Components/Content/BoxContent.tsx
+++ b/styleguide/src/Layout/Box/Components/Content/BoxContent.tsx
@@ -9,7 +9,7 @@ export const BoxContent = React.memo(({ children }: BoxContentProps) => {
   return (
     <div
       className={`box-content ${defaultPaddingVariantsContent[variant]} ${
-        !isOpen && 'hidden'
+        !isOpen ? 'hidden' : ''
       }`}
     >
       {children}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Algumas correções simples.

#### What problem is this solving?

Toggle usando flex é possível clicar fora dele (na mesma linha) e ativar/desativar, inline-flex previne isso;
isOpen estava gerando classe `false`

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
