### PR TITLE
feat: add checkbox option to align the input box

### DIFF
--- a/styleguide/src/Forms/Checkbox/Checkbox.tsx
+++ b/styleguide/src/Forms/Checkbox/Checkbox.tsx
@@ -9,6 +9,7 @@ const CheckboxComponent = (
     checked,
     disabled,
     indeterminate,
+    boxAlign = 'center',
     ...props
   }: CheckboxProps,
   ref: React.ForwardedRef<HTMLInputElement>
@@ -19,6 +20,7 @@ const CheckboxComponent = (
   const [isIndeterminate, setIsIndeterminate] = React.useState(
     !!indeterminate || false
   )
+  const isCenterBoxAlign = boxAlign === 'center'
 
   React.useEffect(() => {
     setIsChecked(!!checked)
@@ -41,13 +43,17 @@ const CheckboxComponent = (
     isChecked || isIndeterminate ? 'scale-100' : 'scale-0'
   }`
 
-  const checkboxIconContainerClasses = `border border-card-stroke transition duration-200 ease-in-out ${
-    disabled
-      ? 'bg-base-4'
-      : isChecked || isIndeterminate
-      ? 'bg-primary border-primary'
-      : 'bg-base-1'
-  }  rounded w-4 h-4 flex justify-center items-center m-px`
+  const checkboxIconContainerClasses = `border border-card-stroke transition duration-200 ease-in-out
+    ${
+      disabled
+        ? 'bg-base-4'
+        : isChecked || isIndeterminate
+        ? 'bg-primary border-primary'
+        : 'bg-base-1'
+    }
+    ${isCenterBoxAlign ? 'items-center' : ''}
+    rounded w-4 h-4 flex justify-center m-px
+  `
 
   const checkboxLabelClasses = `ml-1 input-label text-f6 tracking-4 leading-6 ${
     disabled ? 'text-inverted-2' : ''
@@ -56,7 +62,7 @@ const CheckboxComponent = (
   return (
     <label
       htmlFor={inputId}
-      className="inline-flex items-center cursor-pointer"
+      className={`inline-flex items-${boxAlign} cursor-pointer`}
     >
       <span className="rounded z-50 flex items-center justify-center focus-within:ring-2 ring-focus">
         <input
@@ -110,4 +116,5 @@ export interface CheckboxProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string | React.ReactNode
   indeterminate?: boolean
+  boxAlign?: 'center' | 'baseline'
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the `boxAlign` option to choose the alignment of the checkbox input (center or baseline).

#### What problem is this solving?

The checkox input is always align to the center, but I have the situation when there is a span with multiple lines and I need to align the input with the first span line.

#### How should this be manually tested?

When there is a span with just one line, the baseline and center should have the same effect.
When there is a span with more than one line, the baseline option should align the input box with the first line, and the center option should aslign with center.

#### Screenshots or example usage

### Baseline
Multiple lines:
![image](https://user-images.githubusercontent.com/19414947/145872110-64c11e7e-3c57-4fa8-bc86-38f7212427e8.png)

Single line:
![image](https://user-images.githubusercontent.com/19414947/145872230-ba1f7700-acf8-4f31-ae3a-6b56a2e904ac.png)

### Center
Multiple lines:
![image](https://user-images.githubusercontent.com/19414947/145872401-112f1dd7-3210-4aa4-bc43-9ef942a8adee.png)

Single line:
![image](https://user-images.githubusercontent.com/19414947/145872491-97151c9d-9ef6-4c68-b712-e11e2833a60c.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
