### PR TITLE
Feat/only text button

### DIFF
--- a/styleguide/src/Components/Button/Button.tsx
+++ b/styleguide/src/Components/Button/Button.tsx
@@ -47,7 +47,7 @@ const listOfStylesDisabled = {
   warning: defaultDisabledStyle,
   danger: defaultDisabledStyle,
   outline: defaultDisabledStyle,
-  onlyText: defaultDisabledStyle,
+  onlyText: `bg-transparent text-on-base-3 shadow-none ring-0 border-0`,
 }
 
 const listOfSizes = {

--- a/styleguide/src/Components/Button/Button.tsx
+++ b/styleguide/src/Components/Button/Button.tsx
@@ -10,6 +10,7 @@ const listOfStylesHover = {
   warning: `hover:bg-warning-dark`,
   danger: `hover:bg-danger-dark`,
   outline: `hover:bg-primary-light`,
+  onlyText: `hover:bg-base-2`,
 }
 const listOfStylesActive = {
   primary: `active:bg-primary-bold`,
@@ -35,7 +36,7 @@ const listOfStyles = {
   warning: `bg-warning text-on-base ${listOfStylesHover['warning']} ${listOfStylesActive['warning']}`,
   danger: `bg-danger text-base-1 ${listOfStylesHover['danger']} ${listOfStylesActive['danger']} ${listOfStylesFocus['danger']}`,
   outline: `bg-transparent text-inverted-2 border border-inverted-2 ${listOfStylesHover['outline']} ${listOfStylesActive['outline']} ${listOfStylesFocus['outline']}`,
-  onlyText: `bg-transparent border-transparent text-inverted-2 px-0 ${listOfStylesActive['onlyText']} ${listOfStylesFocus['onlyText']}`,
+  onlyText: `bg-transparent border-transparent text-inverted-2 px-0 ${listOfStylesHover['onlyText']} ${listOfStylesActive['onlyText']} ${listOfStylesFocus['onlyText']}`,
 }
 
 const defaultDisabledStyle = `bg-base-3 cursor-default text-on-base-2 shadow-none ring-0 border-0 hover:bg-base-3 hover:text-on-base-2 `

--- a/styleguide/src/Components/Button/Button.tsx
+++ b/styleguide/src/Components/Button/Button.tsx
@@ -18,12 +18,14 @@ const listOfStylesActive = {
   warning: `active:bg-warning-bold`,
   danger: `hover:bg-danger-bold`,
   outline: `active:shadow-inner active:bg-base-1`,
+  onlyText: `active:bg-base-1`,
 }
 const listOfStylesFocus = {
   primary: `focus:ring-1 focus:ring-primary-dark focus:ring-opacity-50`,
   secondary: `focus:ring focus:ring-focus`,
   danger: `focus:ring-1 focus:ring-danger-dark`,
   outline: `focus:ring-2 focus:ring-focus focus:ring-offset-1`,
+  onlyText: `focus:bg-base-1`,
 }
 const listOfStyles = {
   primary: `bg-primary text-base-1 ${listOfStylesHover['primary']} ${listOfStylesActive['primary']} ${listOfStylesFocus['primary']}`,
@@ -33,6 +35,7 @@ const listOfStyles = {
   warning: `bg-warning text-on-base ${listOfStylesHover['warning']} ${listOfStylesActive['warning']}`,
   danger: `bg-danger text-base-1 ${listOfStylesHover['danger']} ${listOfStylesActive['danger']} ${listOfStylesFocus['danger']}`,
   outline: `bg-transparent text-inverted-2 border border-inverted-2 ${listOfStylesHover['outline']} ${listOfStylesActive['outline']} ${listOfStylesFocus['outline']}`,
+  onlyText: `bg-transparent border-transparent text-inverted-2 px-0 ${listOfStylesActive['onlyText']} ${listOfStylesFocus['onlyText']}`,
 }
 
 const defaultDisabledStyle = `bg-base-3 cursor-default text-on-base-2 shadow-none ring-0 border-0 hover:bg-base-3 hover:text-on-base-2 `
@@ -44,6 +47,7 @@ const listOfStylesDisabled = {
   warning: defaultDisabledStyle,
   danger: defaultDisabledStyle,
   outline: defaultDisabledStyle,
+  onlyText: defaultDisabledStyle,
 }
 
 const listOfSizes = {
@@ -150,6 +154,7 @@ export interface ButtonProps extends ButtonAnchorProps {
     | 'warning'
     | 'danger'
     | 'outline'
+    | 'onlyText'
   /**
    * Button is loading
    * */

--- a/styleguide/src/Forms/Checkbox/Checkbox.tsx
+++ b/styleguide/src/Forms/Checkbox/Checkbox.tsx
@@ -59,10 +59,18 @@ const CheckboxComponent = (
     disabled ? 'text-inverted-2' : ''
   }`
 
+  const alignOptions = {
+    start: 'items-start',
+    end: 'items-end',
+    center: 'items-center',
+    baseline: 'items-baseline',
+    stretch: 'items-stretch',
+  }
+
   return (
     <label
       htmlFor={inputId}
-      className={`inline-flex items-${boxAlign} cursor-pointer`}
+      className={`inline-flex ${alignOptions[boxAlign]} cursor-pointer`}
     >
       <span className="rounded z-50 flex items-center justify-center focus-within:ring-2 ring-focus">
         <input
@@ -116,5 +124,5 @@ export interface CheckboxProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string | React.ReactNode
   indeterminate?: boolean
-  boxAlign?: 'center' | 'baseline'
+  boxAlign?: 'start' | 'end' | 'center' | 'baseline' | 'stretch'
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add button variant to support the `onlyText` feature as the design system was designed.
Prevent a problem with checkbox about tailwind classes mounting ([tailwind doc](https://tailwindcss.com/docs/content-configuration#class-detection-in-depth)).

#### What problem is this solving?
New variant to the button.
Prevent tailwind issue.

#### How should this be manually tested?
It's possible to test using storybook and compare with [Figma](https://www.figma.com/file/Z2WDD4SH8zwaJC2K5wbtMO/Sistema-Integrado?node-id=84%3A4800).

The checkbox fix does not change anything, it can be tested just making sure that everything keeps working.

#### Screenshots or example usage
The `onlyText` button starts with transparent background:
![image](https://user-images.githubusercontent.com/19414947/148253712-3d9222e9-50e5-4217-8c1a-cc0cba1101e2.png)

When it is activated or focus the background becomes white:
![image](https://user-images.githubusercontent.com/19414947/148253865-bd6645fc-2c03-4d88-98b1-bc01a746cbec.png)


#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
