### PR TITLE
Set default type for button

### DIFF
--- a/styleguide/src/Components/Button/Button.tsx
+++ b/styleguide/src/Components/Button/Button.tsx
@@ -73,6 +73,10 @@ const ButtonType = React.forwardRef(
           {children}
         </a>
       )
+    if (!props.type) {
+      // Default to button when missing type
+      props.type = 'button'
+    }
     return (
       <button {...props} ref={ref}>
         {children}

--- a/styleguide/src/Layout/ActionBar/ActionBar.tsx
+++ b/styleguide/src/Layout/ActionBar/ActionBar.tsx
@@ -59,6 +59,7 @@ const ActionBarComponent = ({ onlyMobile, children }: ActionBarProps) => {
                   (props?.loading ? ' pointer-events-none' : '')
                 }
                 onClick={props?.onClick}
+                type={props?.type || 'button'}
               >
                 {props?.loading ? (
                   <Icon icon="loading" className="p-px" />


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Valor padrão `type` do `<Button>` ser `button`

#### What problem is this solving?
- Caso nenhum type seja enviado, o browser considera como `submit`, podendo causar cenários não esperados

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
