### PR TITLE
feat: add prop expanded in badge component

### DIFF
--- a/styleguide/src/Indicators/Badge/Badge.spec.tsx
+++ b/styleguide/src/Indicators/Badge/Badge.spec.tsx
@@ -3,7 +3,7 @@ import { composeStories } from "@storybook/testing-react"
 import { mount } from "@cypress/react"
 import * as stories from "./Badge.stories"
 
-const { Default, Small } = composeStories(stories)
+const { Default, Small, Expanded } = composeStories(stories)
 const badgeClass = '.badge'
 
 describe('Badge tests', () => {
@@ -17,6 +17,11 @@ describe('Badge tests', () => {
   it('Small', () => {
     mount(<Small />)
     cy.get(badgeClass).should('have.class', 'px-1')
+  })
+
+  it('Expanded', () => {
+    mount(<Expanded />)
+    cy.get(badgeClass).should('have.class', 'w-full')
   })
 
   it('Variants', () => {

--- a/styleguide/src/Indicators/Badge/Badge.stories.tsx
+++ b/styleguide/src/Indicators/Badge/Badge.stories.tsx
@@ -21,9 +21,18 @@ export default {
   },
 } as Meta
 
-const Template: Story<BadgeProps> = args => <Badge {...args} />
+const Template: Story<BadgeProps> = args => (
+  <div className="w-48 flex justify-center items-center">
+    <Badge {...args} />
+  </div>
+)
 
 export const Default = Template.bind({})
+
+export const Expanded = Template.bind({})
+Expanded.args = {
+  expanded: true,
+}
 
 export const Small = Template.bind({})
 Small.args = {

--- a/styleguide/src/Indicators/Badge/Badge.tsx
+++ b/styleguide/src/Indicators/Badge/Badge.tsx
@@ -17,10 +17,13 @@ const BadgeComponent = ({
   type = 'neutral',
   text,
   size = 'default',
+  expanded = false,
 }: BadgeProps) => {
   return (
     <div
-      className={`badge inline-flex items-center justify-center rounded-full ${badgeTypes[type]} ${badgeSizes[size]}`}
+      className={`badge items-center justify-center rounded-full ${
+        badgeTypes[type]
+      } ${badgeSizes[size]} ${expanded ? 'flex w-full' : 'inline-flex'}`}
     >
       <span className={`text-xs tracking-4 font-semibold text-base-1`}>
         {text}
@@ -44,4 +47,8 @@ export interface BadgeProps {
    * @default default
    * */
   size?: keyof typeof badgeSizes
+  /**
+   * Enlarge width of the badge
+   * */
+  expanded?: boolean
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adiciona prop `expanded` para permitir width adaptativo para o componente `badge`.

#### What problem is this solving?

Badge tinha um tamanho fixado no conteúdo, não permitindo sua expansão, para usar como na imagem abaixo:

<img width="152" alt="image" src="https://user-images.githubusercontent.com/7097946/156819806-3da7d5f5-7045-4d2c-8a2c-06cb63f66650.png">


#### How should this be manually tested?
https://60d36f60766f7d0045e93767-pftepdbhup.chromatic.com/?path=/story/indicators-badge--expanded

#### Screenshots or example usage

<img width="238" alt="image" src="https://user-images.githubusercontent.com/7097946/156819580-9b6908e9-d701-4c93-874f-215638a05479.png">

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
