### PR TITLE
feat: add prop to show/hide toggle in timeline item

### DIFF
--- a/styleguide/src/Components/Timeline/Timeline.spec.tsx
+++ b/styleguide/src/Components/Timeline/Timeline.spec.tsx
@@ -3,7 +3,7 @@ import { composeStories } from "@storybook/testing-react"
 import { mount } from "@cypress/react"
 import * as stories from "./Timeline.stories"
 
-const { Default, Loading, Empty } = composeStories(stories)
+const { Default, WithoutToggle, Loading, Empty } = composeStories(stories)
 
 describe('Timeline tests', () => {
 
@@ -17,6 +17,18 @@ describe('Timeline tests', () => {
         cy.get('.timeline-description').should('not.be.visible')
         cy.get('.timeline-title button').click()
         cy.get('.timeline-description').should('be.visible')
+      })
+  })
+
+  it('Without Toggle', () => {
+    mount(<WithoutToggle />)
+    cy.get('.timeline .timeline-item')
+      .should('have.length', 4)
+      .first().within(() => {
+        cy.get('.timeline-title').contains('Venda criada')
+        cy.get('.timeline-timestamp').contains('11/11/2011')
+        cy.get('.timeline-description').should('be.visible')
+        cy.get('.timeline-title button').should('not.exist')
       })
   })
 

--- a/styleguide/src/Components/Timeline/Timeline.stories.tsx
+++ b/styleguide/src/Components/Timeline/Timeline.stories.tsx
@@ -22,9 +22,10 @@ export default {
         title: 'Venda criada',
       },
       {
-        title: 'Vendacriadadacriadadacriadadacriadadacriadadacriadadacriadadacriadadacriadadacriadadacriadadacriada',
+        title: 'Venda criada sem toggle',
         iconBackgroundColor: 'bg-danger',
         description: 'Status change: from Cancelling to Cancelled',
+        toggle: false,
       },
       {
         title: 'Venda criada',
@@ -38,6 +39,11 @@ export default {
 const Template: Story<TimelineProps> = args => <Timeline {...args} />
 
 export const Default = Template.bind({})
+
+export const WithoutToggle = Template.bind({})
+WithoutToggle.args = {
+  toggleItems: false,
+}
 
 export const Loading = Template.bind({})
 Loading.args = {

--- a/styleguide/src/Components/Timeline/Timeline.tsx
+++ b/styleguide/src/Components/Timeline/Timeline.tsx
@@ -8,6 +8,7 @@ const TimelineComponent = ({
   className = '',
   items,
   isLoading = false,
+  toggleItems = true,
   emptyTitle = 'Nenhum registro encontrado',
 }: TimelineProps) => {
   if (!isLoading && (!items || !Array.isArray(items))) return null
@@ -37,7 +38,10 @@ const TimelineComponent = ({
           />
         ) : (
           items?.map((item, index) => (
-            <TimelineItem key={`timeline-item-${index}`} item={item} />
+            <TimelineItem
+              key={`timeline-item-${index}`}
+              item={{ ...item, toggle: item.toggle ?? toggleItems }}
+            />
           ))
         )}
       </ul>
@@ -64,4 +68,8 @@ export interface TimelineProps {
    * @default 'Nenhum registro encontrado'
    */
   emptyTitle?: string
+  /** Timeline item show toggle
+   * @default true
+   */
+  toggleItems?: boolean
 }

--- a/styleguide/src/Components/Timeline/TimelineItem.interface.ts
+++ b/styleguide/src/Components/Timeline/TimelineItem.interface.ts
@@ -21,4 +21,8 @@ export interface TimelineItemInterface {
    * Background of the current icon (className)
    */
   iconBackgroundColor?: string
+  /**
+   * Toggle item description
+   */
+  toggle?: boolean
 }

--- a/styleguide/src/Components/Timeline/TimelineItem.tsx
+++ b/styleguide/src/Components/Timeline/TimelineItem.tsx
@@ -4,9 +4,10 @@ import { Icon } from '../../Icons/Icon'
 import { TimelineItemInterface } from './TimelineItem.interface'
 
 export const TimelineItem = ({ item }: TimelineItemProps) => {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(!item.toggle)
   const iconBackgroundColor = item.iconBackgroundColor || `bg-inverted-2`
   const icon = item.icon || 'minus'
+  const showToggle = item.toggle && item.description
 
   return (
     <li className={`timeline-item relative mb-10 last:mb-0`}>
@@ -17,12 +18,12 @@ export const TimelineItem = ({ item }: TimelineItemProps) => {
       </div>
       <div className="ml-7 pt-px">
         <div
-          className={`timeline-title group mb-1 py-1 text-sm text-inverted-1 font-semibold break-words ${
-            item.description ? 'cursor-pointer' : ''
+          className={`timeline-title group py-1 text-f6 leading-6 tracking-4 text-inverted-1 font-semibold break-words ${
+            showToggle ? 'cursor-pointer' : ''
           }`}
-          onClick={() => item.description && setIsOpen((isOpen) => !isOpen)}
+          onClick={() => showToggle && setIsOpen((isOpen) => !isOpen)}
         >
-          {item.description && (
+          {showToggle && (
             <button
               className={`float-right p-1 -mt-px text-inverted-2 group-hover:text-inverted-1 focus:outline-none`}
             >
@@ -39,13 +40,14 @@ export const TimelineItem = ({ item }: TimelineItemProps) => {
           <span className="inline break-words">{item.title}</span>
         </div>
         {item.timestamp && (
-          <div className="timeline-timestamp mb-1 text-xs text-inverted-2 break-words">
+          <div className="timeline-timestamp mb-1 inline-flex items-center text-xs tracking-4 text-inverted-2 break-words">
+            <Icon icon="clock" size={3} className="mr-1" />
             {item.timestamp}
           </div>
         )}
         {item.description && (
           <div
-            className={`timeline-description overflow-hidden text-sm text-inverted-1 break-words transition-max-height ${
+            className={`timeline-description overflow-hidden text-sm tracking-4 text-inverted-1 break-words transition-max-height ${
               isOpen ? 'max-h-96' : 'max-h-0'
             }`}
           >


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adiciona prop `toggleItems` no componente `Timeline` para gerenciar exibição do toggle em um item de timeline.

É possível definir individualmente o estado da exibição do toggle em um item.

Adiciona também ícone do relógio ao lado do timestamp.

#### What problem is this solving?

No Enviali deixaremos visível a descrição de um item, sem toggle.

#### How should this be manually tested?

https://60d36f60766f7d0045e93767-tnyhufzopz.chromatic.com/?path=/story/components-timeline--without-toggle

#### Screenshots or example usage

<img width="816" alt="image" src="https://user-images.githubusercontent.com/7097946/158439571-952ab462-63eb-4231-9e4f-d832162344c9.png">


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
