### PR TITLE
feat: add prop custom icon to alert

### DIFF
--- a/styleguide/src/Indicators/Alert/Alert.tsx
+++ b/styleguide/src/Indicators/Alert/Alert.tsx
@@ -68,7 +68,10 @@ const AlertComponent = ({
         <div
           className={`alert-icon hidden sm:block flex-shrink-0 mr-3 ${alertTypes[type].iconClass}`}
         >
-          <Icon icon={customIcon ? customIcon : alertTypes[type].icon} size={6} />
+          <Icon
+            icon={customIcon ? customIcon : alertTypes[type].icon}
+            size={6}
+          />
         </div>
       )}
       <div className="flex-grow flex flex-col sm:flex-row items-start sm:items-center justify-between min-w-0">
@@ -130,7 +133,7 @@ export interface AlertProps {
   /**
    * Custom icon
    */
-   customIcon?: IconProps['icon']
+  customIcon?: IconProps['icon']
   /**
    * Action for the alert, like button and hiperlinks
    * */

--- a/styleguide/src/Indicators/Alert/Alert.tsx
+++ b/styleguide/src/Indicators/Alert/Alert.tsx
@@ -47,6 +47,7 @@ const AlertComponent = ({
   showClose = false,
   onClose,
   hideIcon = false,
+  customIcon,
 }: AlertProps) => {
   const [alertIsOpen, setAlertIsOpen] = useState(isOpen)
   useEffect(() => {
@@ -67,7 +68,7 @@ const AlertComponent = ({
         <div
           className={`alert-icon hidden sm:block flex-shrink-0 mr-3 ${alertTypes[type].iconClass}`}
         >
-          <Icon icon={alertTypes[type].icon} size={6} />
+          <Icon icon={customIcon ? customIcon : alertTypes[type].icon} size={6} />
         </div>
       )}
       <div className="flex-grow flex flex-col sm:flex-row items-start sm:items-center justify-between min-w-0">
@@ -126,6 +127,10 @@ export interface AlertProps {
    * @default false
    */
   hideIcon?: boolean
+  /**
+   * Custom icon
+   */
+   customIcon?: IconProps['icon']
   /**
    * Action for the alert, like button and hiperlinks
    * */


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adicionando prop `customIcon` para o componente de alert.

#### What problem is this solving?

Necessidade de usar um ícone personalizado para uma alert. Ex: 
<img width="794" alt="image" src="https://user-images.githubusercontent.com/7097946/163197273-93f01495-84d0-47aa-8927-6b542840526d.png">
https://www.figma.com/file/Z2WDD4SH8zwaJC2K5wbtMO/Sistema-Integrado?node-id=3%3A3743

#### How should this be manually tested?

Alterando a propriedade `customIcon`, o ícone da alert deve mudar de acordo com o selecionado.
https://60d36f60766f7d0045e93767-hqbgvntwlq.chromatic.com/?path=/story/indicators-alert--default&args=type:danger;customIcon:exclamationCircle

#### Screenshots or example usage

<img width="915" alt="image" src="https://user-images.githubusercontent.com/7097946/163197438-84eda1e0-647c-42b6-afa3-c4bca2cfa4a0.png">

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
