### PR TITLE
Fix breadcrumb previous option without title

### DIFF
--- a/styleguide/src/Components/Timeline/TimelineItem.tsx
+++ b/styleguide/src/Components/Timeline/TimelineItem.tsx
@@ -47,7 +47,7 @@ export const TimelineItem = ({ item }: TimelineItemProps) => {
         )}
         {item.description && (
           <div
-            className={`timeline-description overflow-hidden text-sm tracking-4 text-inverted-1 break-words transition-max-height ${
+            className={`timeline-description mt-1 overflow-hidden text-sm tracking-4 text-inverted-1 break-words transition-max-height ${
               isOpen ? 'max-h-96' : 'max-h-0'
             }`}
           >

--- a/styleguide/src/Navigation/Breadcrumb/index.tsx
+++ b/styleguide/src/Navigation/Breadcrumb/index.tsx
@@ -131,11 +131,11 @@ export interface BreadcrumbProps {
   /**
    * Current page title
    * */
-  currentTitle: string
+  currentTitle: string | React.ReactNode
   /**
    * Previous page title
    * */
-  previousTitle?: string
+  previousTitle?: string | React.ReactNode
   /**
    * Previous page href
    * */

--- a/styleguide/src/Navigation/Breadcrumb/index.tsx
+++ b/styleguide/src/Navigation/Breadcrumb/index.tsx
@@ -62,7 +62,7 @@ export const Breadcrumb: React.FC<BreadcrumbProps> = React.memo(
           className={`header-navigation-breadcrumb max-w-full truncate w-full`}
         >
           <div className="w-full inline-flex self-center items-center font-semibold tracking-5 text-f5 sm:text-f4 lg:text-f3">
-            {(previousTitle || previousHref) && (
+            {(previousTitle || previousHref || Link) && (
               <span className="header-navigation-previous inline-flex items-center text-on-base-2 text-xl -mr-px truncate">
                 {renderPrevLink()}
                 {previousTitle && (


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Breadcrumb title accept react node
- Breadcrumb previous accept only Link without title
- Timeline description additional margin

#### What problem is this solving?
- Pequenos ajustes nos componentes

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
