### PR TITLE
fix: button small size

### DIFF
--- a/styleguide/src/Components/Button/Button.spec.tsx
+++ b/styleguide/src/Components/Button/Button.spec.tsx
@@ -19,7 +19,7 @@ describe('Button tests', () => {
 
   it('Small', () => {
     mount(<Small />)
-    cy.get('button').should('have.class', 'h-8')
+    cy.get('button').should('have.class', 'h-10')
   })
 
   it('Action', () => {

--- a/styleguide/src/Components/Button/Button.tsx
+++ b/styleguide/src/Components/Button/Button.tsx
@@ -57,7 +57,7 @@ const listOfStylesDisabled = {
 }
 
 const listOfSizes = {
-  small: `text-f7 h-8`,
+  small: `text-f6 h-10`,
   default: `text-f6 h-12`,
   large: `text-f5 h-14`,
 }

--- a/styleguide/src/Forms/Input/Input.spec.tsx
+++ b/styleguide/src/Forms/Input/Input.spec.tsx
@@ -51,7 +51,7 @@ describe('Input tests', () => {
     cy.get('input').parent().should('have.class', 'h-12')
 
     mount(<Default variant="small" />)
-    cy.get('input').parent().should('have.class', 'h-8')
+    cy.get('input').parent().should('have.class', 'h-10')
 
     mount(<Default variant="large" />)
     cy.get('input').parent().should('have.class', 'h-14')

--- a/styleguide/src/Forms/commonStyles.ts
+++ b/styleguide/src/Forms/commonStyles.ts
@@ -23,7 +23,7 @@ export const sufixClasses = `${adornmentClasses} rounded-r right-0`
 
 export const variantClasses = {
   default: 'h-12',
-  small: 'h-8',
+  small: 'h-10',
   large: 'h-14',
   xlarge: 'h-24',
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Ajusta tamanho da fonte e altura do botão `small`.

#### What problem is this solving?

Botão `small` estava menor do que o [previsto no design system](https://www.figma.com/file/Z2WDD4SH8zwaJC2K5wbtMO/Sistema-Integrado?node-id=95%3A7094).

#### How should this be manually tested?
https://60d36f60766f7d0045e93767-bjxjswsrso.chromatic.com/?path=/story/components-button--small

#### Screenshots or example usage
antes:
<img width="160" alt="image" src="https://user-images.githubusercontent.com/7097946/176954674-e39fcffa-b93e-44a8-ab9d-5d41512c9a25.png">
depois:
<img width="156" alt="image" src="https://user-images.githubusercontent.com/7097946/176954715-ab233044-3b5f-4321-af0e-b7dd47488d86.png">


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
