### PR TITLE
adds new focus colors and info variant

### DIFF
--- a/styleguide/src/Indicators/InformationBox/InformationBox.spec.tsx
+++ b/styleguide/src/Indicators/InformationBox/InformationBox.spec.tsx
@@ -23,5 +23,9 @@ describe('InformationBox tests', () => {
     mount(<Default type="danger" />)
     cy.get('.InformationBox-icon').should('have.class', 'icon-ban')
     cy.get('.InformationBox').should('have.class', 'bg-danger-light')
+    
+    mount(<Default type="info" />)
+    cy.get('.InformationBox-icon').should('have.class', 'icon-infoCircle')
+    cy.get('.InformationBox').should('have.class', 'bg-focus-light')
   })
 })

--- a/styleguide/src/Indicators/InformationBox/InformationBox.tsx
+++ b/styleguide/src/Indicators/InformationBox/InformationBox.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Icon, IconProps } from '../../Icons'
 
-type InformationBoxTypesOptions = 'tip' | 'warning' | 'danger'
+type InformationBoxTypesOptions = 'tip' | 'warning' | 'danger' | 'info'
 
 const InformationBoxTypes: Record<
   InformationBoxTypesOptions,
@@ -29,6 +29,12 @@ const InformationBoxTypes: Record<
     class: 'bg-danger-light border-danger',
     icon: 'ban',
     iconClass: 'text-danger',
+  },
+  info: {
+    title: 'Informação!',
+    class: 'bg-focus-light border-focus-dark',
+    icon: 'infoCircle',
+    iconClass: 'text-focus-dark',
   },
 }
 

--- a/tailwindcss/src/defaultPreset.js
+++ b/tailwindcss/src/defaultPreset.js
@@ -71,7 +71,9 @@ module.exports = {
       "card-stroke-2": "#A3AAB5",
       "card-shadow": "#E1E4E7",
 
-      "focus": "#5690F7"
+      "focus": "#5690F7",
+      "focus-light": "#F3F8FF",
+      "focus-dark": "#2596be"
     },
     "extend": {
       "boxShadow": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds the new 'info' variant to informationBox component and it's corresponding color palette

#### What problem is this solving?

The lack of both variant and color palette

#### How should this be manually tested?

#### Screenshots or example usage
![Screen Shot 2022-10-25 at 11 17 42](https://user-images.githubusercontent.com/43355628/197798555-e6e6e834-9422-4012-8544-15bf024a274d.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
