### PR TITLE
Add title property to SidebarFixed

### DIFF
--- a/styleguide/src/Components/SidebarFixed/SidebarFixed.tsx
+++ b/styleguide/src/Components/SidebarFixed/SidebarFixed.tsx
@@ -15,6 +15,7 @@ export const SidebarFixedComponent: React.FC<SidebarFixedProps> = ({
   footerActions,
   isOpen = false,
   onClose,
+  title,
   helpLink,
 }) => {
   const [sidebarIsOpen, setSidebarIsOpen] = useState(false)
@@ -46,22 +47,29 @@ export const SidebarFixedComponent: React.FC<SidebarFixedProps> = ({
         }`}
       >
         <div className="sidebar-fixed-header flex justify-between items-center p-3 lg:px-5 text-inverted-2">
-          <button
-            className="sidebar-fixed-close p-2 hover:text-primary transition-colors"
-            onClick={handleRequestCloseFunc}
-          >
-            <Icon icon="close" block size={4} />
-          </button>
-          {helpLink && (
-            <a
-              className="sidebar-fixed-help p-2 hover:text-primary transition-colors"
-              href={helpLink}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <Icon icon="questionCircle" block size={4} />
-            </a>
+          {title && (
+            <div className="px-2 py-5 text-f4 font-semibold text-inverted-1">
+              {title}
+            </div>
           )}
+          <div className={`flex justify-between${title ? '' : ' flex-1'}`}>
+            <button
+              className="sidebar-fixed-close p-2 hover:text-primary transition-colors"
+              onClick={handleRequestCloseFunc}
+            >
+              <Icon icon="close" block size={4} />
+            </button>
+            {helpLink && (
+              <a
+                className="sidebar-fixed-help p-2 hover:text-primary transition-colors"
+                href={helpLink}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <Icon icon="questionCircle" block size={4} />
+              </a>
+            )}
+          </div>
         </div>
         <div
           className={`sidebar-fixed-content flex-1 flex-grow w-full overflow-auto overscroll-none px-5 lg:px-7 break-words ${backgroundShadowEffect.join(
@@ -100,6 +108,10 @@ export interface SidebarFixedProps {
    * Call when sidebar is closed
    * */
   onClose?: Function
+  /**
+   * Title displayed in header
+   */
+  title?: string
   /**
    * Help external link
    */

--- a/styleguide/src/Components/SidebarFixed/SidebarFixed.tsx
+++ b/styleguide/src/Components/SidebarFixed/SidebarFixed.tsx
@@ -48,7 +48,7 @@ export const SidebarFixedComponent: React.FC<SidebarFixedProps> = ({
       >
         <div className="sidebar-fixed-header flex justify-between items-center p-3 lg:px-5 text-inverted-2">
           {title && (
-            <div className="sidebar-fixed-title px-2 py-5 text-f4 font-semibold text-inverted-1">
+            <div className="sidebar-fixed-title px-2 py-2 sm:py-5 text-f5 sm:text-f4 font-semibold text-inverted-1">
               {title}
             </div>
           )}

--- a/styleguide/src/Components/SidebarFixed/SidebarFixed.tsx
+++ b/styleguide/src/Components/SidebarFixed/SidebarFixed.tsx
@@ -48,7 +48,7 @@ export const SidebarFixedComponent: React.FC<SidebarFixedProps> = ({
       >
         <div className="sidebar-fixed-header flex justify-between items-center p-3 lg:px-5 text-inverted-2">
           {title && (
-            <div className="px-2 py-5 text-f4 font-semibold text-inverted-1">
+            <div className="sidebar-fixed-title px-2 py-5 text-f4 font-semibold text-inverted-1">
               {title}
             </div>
           )}


### PR DESCRIPTION
#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

Não era possível adicionar um título no cabeçalho alinhado com os botões de ação.

#### How should this be manually tested?

Manter o mesmo comportamento/posição dos elementos quando não houver título. Quando tiver, o título deverá ficar alinhado à esquerda e os botões de ação à direita.

#### Screenshots or example usage

![figma](https://user-images.githubusercontent.com/17346972/200921228-dadd6557-250c-44da-abfd-c962c6b998d3.png)

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
