### PR TITLE
fix: onlyText classes

### DIFF
--- a/styleguide/src/Components/Button/Button.tsx
+++ b/styleguide/src/Components/Button/Button.tsx
@@ -53,7 +53,7 @@ const listOfStylesDisabled = {
   warning: defaultDisabledStyle,
   danger: defaultDisabledStyle,
   outline: defaultDisabledStyle,
-  onlyText: `bg-transparent text-on-base-3 shadow-none ring-0 border-0`,
+  onlyText: `bg-transparent text-on-base-3 shadow-none ring-0 border-0 `,
 }
 
 const listOfSizes = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix button style when variant is onlyText;

#### What problem is this solving?
Glued classes, ex: `border-0text-f6`
<img width="529" alt="image" src="https://user-images.githubusercontent.com/7097946/218227478-2d39fd29-2af0-4cf1-9f46-0b13ab7f0028.png">

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
