### PR TITLE
fix: adjust color focus dark

### DIFF
--- a/tailwindcss/src/_variables.scss
+++ b/tailwindcss/src/_variables.scss
@@ -55,7 +55,7 @@
   --color-card-shadow: 225 228 231;
   --color-focus: 86 144 247;
   --color-focus-light: 243 248 255;
-  --color-focus-dark: 37 150 190;
+  --color-focus-dark: 37 99 235;
 }
 
 html {
@@ -117,6 +117,6 @@ html {
     --color-card-shadow: 100 100 100;
     --color-focus: 221 221 221;
     --color-focus-light: 62 66 74;
-    --color-focus-dark: 37 150 190;
+    --color-focus-dark: 37 99 235;
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Atualizando cor `focus-dark` de acordo com o "Sistema Integrado":
<img width="239" alt="image" src="https://github.com/lojaintegrada/admin-components/assets/7097946/a33b509b-ccd7-4ae5-a334-78f2c1532cbb">

Cor atual:
![image](https://github.com/lojaintegrada/admin-components/assets/7097946/fa12f2e8-cbae-4feb-9086-8ef63adfb574)


#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
