### PR TITLE
Add variant in Status component

### DIFF
--- a/styleguide/src/Indicators/Status/Status.spec.tsx
+++ b/styleguide/src/Indicators/Status/Status.spec.tsx
@@ -21,6 +21,9 @@ describe(specTitle('Status tests'), () => {
     mount(<Default type="success" />)
     cy.get('.indicator-status').find('.rounded-full').should('have.class', 'bg-success')
 
+    mount(<Default type="successDark" />)
+    cy.get('.indicator-status').find('.rounded-full').should('have.class', 'bg-success-dark')
+
     mount(<Default type="warning" />)
     cy.get('.indicator-status').find('.rounded-full').should('have.class', 'bg-warning')
 
@@ -34,6 +37,11 @@ describe(specTitle('Status tests'), () => {
   it('Inverted', () => {
     mount(<Default inverted={true} />)
     cy.get('.indicator-status *').first().contains('Aprovado')
+  })
+
+  it('Description', () => {
+    mount(<Default description={<strong>Aprovado</strong>} />)
+    cy.get('.indicator-status').find('strong').contains('Aprovado')
   })
 
 })

--- a/styleguide/src/Indicators/Status/Status.tsx
+++ b/styleguide/src/Indicators/Status/Status.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 const statusTypes = {
   default: 'bg-inverted-2',
   success: 'bg-success',
+  successDark: 'bg-success-dark',
   warning: 'bg-warning',
   danger: 'bg-danger',
   dangerLight: 'bg-danger-light',
@@ -56,7 +57,7 @@ export interface StatusProps {
   /**
    * Status additional text
    * */
-  description?: string
+  description?: React.ReactNode | string
   /** Invert icon and text position
    * @default false
    * */


### PR DESCRIPTION
Além do suporte a nova cor de fundo (bg-success-dark), foi permitido enviar um elemento na propriedade 'description'.