### PR TITLE
Add complement to Tabs component

### DIFF
--- a/styleguide/src/Components/Tabs/Tabs.spec.tsx
+++ b/styleguide/src/Components/Tabs/Tabs.spec.tsx
@@ -35,4 +35,11 @@ describe(specTitle('Tabs tests'), () => {
       .get('span').contains('Cupons de desconto')
   })
 
+  it('Title complement', () => {
+    mount(<Default />)
+    cy.get('.tabs .tabs-item').eq(2).within(() => {
+      cy.get('span').contains('Todos os relatórios da loja')
+      cy.get('span').contains('NOVO')
+    })
+  })
 })

--- a/styleguide/src/Components/Tabs/Tabs.stories.tsx
+++ b/styleguide/src/Components/Tabs/Tabs.stories.tsx
@@ -3,6 +3,7 @@ import { Story, Meta } from '@storybook/react'
 import { withDesign } from 'storybook-addon-designs'
 
 import { Tabs, TabsProps } from './Tabs'
+import { Badge } from '../../Indicators'
 
 export default {
   title: 'Components/Tabs',
@@ -32,7 +33,13 @@ export default {
       },
       {
         id: 'relatorios',
-        title: 'Todos os relatorio da loja',
+        title: 'Todos os relatórios da loja',
+        titleComplement: (
+          <Badge
+            text="NOVO"
+            type="primary"
+          />
+        ),
       },
       {
         id: 'vendas',

--- a/styleguide/src/Components/Tabs/TabsItem.interface.ts
+++ b/styleguide/src/Components/Tabs/TabsItem.interface.ts
@@ -8,6 +8,10 @@ export interface TabsItemInterface {
    */
   title: string
   /**
+   * Complement to title
+   * */
+  titleComplement?: string | React.ReactNode
+  /**
    * Disabled a specific tab
    */
   disabled?: boolean

--- a/styleguide/src/Components/Tabs/TabsItem.tsx
+++ b/styleguide/src/Components/Tabs/TabsItem.tsx
@@ -21,6 +21,7 @@ interface TabsItemProps extends TabsItemInterface {
 export const TabsItem = ({
   id,
   title,
+  titleComplement,
   active = false,
   disabled = false,
   onChange,
@@ -44,6 +45,7 @@ export const TabsItem = ({
         data-title={title}
       >
         {title}
+        {titleComplement && <span className="ml-2">{titleComplement}</span>}
       </span>
     </button>
   )


### PR DESCRIPTION
Novo atributo `titleComplement` suportado na lista de itens, necessário para casos onde deve-se ter um elemento ao lado do texto.

![image](https://github.com/lojaintegrada/admin-components/assets/17346972/b0ff8bae-4db9-4b89-ae96-fe032ac23c45)
